### PR TITLE
Add basic size logging for the objects returned from queries.

### DIFF
--- a/logging.conf.sample
+++ b/logging.conf.sample
@@ -1,5 +1,5 @@
 [loggers]
-keys=root,process,seed,intersect,drain,enqueue_tiles_of_interest,wof_process_neighbourhoods
+keys=root,process,seed,intersect,drain,enqueue_tiles_of_interest,wof_process_neighbourhoods,query
 
 [handlers]
 keys=consoleHandler
@@ -45,6 +45,12 @@ propagate=0
 level=INFO
 handlers=consoleHandler
 qualName=wof_process_neighbourhoods
+propagate=0
+
+[logger_query]
+level=DEBUG
+handlers=consoleHandler
+qualName=query
 propagate=0
 
 [handler_consoleHandler]

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -100,7 +100,7 @@ def _preprocess_data(feature_layers):
                                 output_val = output_val.encode('utf-8')
                             props[output_key] = output_val
                             feature_size += len(output_key) + \
-                                            _sizeof(output_val)
+                                _sizeof(output_val)
                 else:
                     props[k] = v
                     feature_size += len(k) + _sizeof(v)

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -30,6 +30,23 @@ def resolve_transform_fns(fn_dotted_names):
     return map(resolve, fn_dotted_names)
 
 
+def _sizeof(val):
+    size = 0
+
+    if isinstance(val, dict):
+        for k, v in val.items():
+            size += len(k) + _sizeof(v)
+    elif isinstance(val, list):
+        for v in val:
+            size += _sizeof(v)
+    elif isinstance(val, (str, bytes, unicode)):
+        size += len(val)
+    else:
+        size += getsizeof(val)
+
+    return size
+
+
 def _preprocess_data(feature_layers):
     preproc_feature_layers = []
     extra_data = dict(size={})
@@ -82,10 +99,11 @@ def _preprocess_data(feature_layers):
                             if isinstance(output_val, unicode):
                                 output_val = output_val.encode('utf-8')
                             props[output_key] = output_val
-                            feature_size += len(output_key) + len(output_val)
+                            feature_size += len(output_key) + \
+                                            _sizeof(output_val)
                 else:
                     props[k] = v
-                    feature_size += len(k) + len(v)
+                    feature_size += len(k) + _sizeof(v)
 
             feature = shape, props, feature_id
             features.append(feature)

--- a/tilequeue/query.py
+++ b/tilequeue/query.py
@@ -3,7 +3,6 @@ from tilequeue.postgresql import DBAffinityConnectionsNoLimit
 from tilequeue.tile import calc_meters_per_pixel_dim
 from tilequeue.tile import coord_to_mercator_bounds
 import sys
-import logging
 
 
 def generate_query(start_zoom, template, bounds, zoom):
@@ -83,13 +82,6 @@ def execute_query(conn, query, layer_datum, padded_bounds):
         cursor = conn.cursor(cursor_factory=RealDictCursor)
         cursor.execute(query)
         rows = list(cursor.fetchall())
-
-        # if we are debugging this layer, then print out the size of the
-        # results returned from the server.
-        if layer_datum.get('debug_query_size'):
-            logger = logging.getLogger('query')
-            logger.debug('Layer[%r]: %d bytes' %
-                         (layer_datum.get('name'), sys.getsizeof(rows)))
 
         return rows, layer_datum, padded_bounds
     except:

--- a/tilequeue/query.py
+++ b/tilequeue/query.py
@@ -3,6 +3,7 @@ from tilequeue.postgresql import DBAffinityConnectionsNoLimit
 from tilequeue.tile import calc_meters_per_pixel_dim
 from tilequeue.tile import coord_to_mercator_bounds
 import sys
+import logging
 
 
 def generate_query(start_zoom, template, bounds, zoom):
@@ -82,6 +83,14 @@ def execute_query(conn, query, layer_datum, padded_bounds):
         cursor = conn.cursor(cursor_factory=RealDictCursor)
         cursor.execute(query)
         rows = list(cursor.fetchall())
+
+        # if we are debugging this layer, then print out the size of the
+        # results returned from the server.
+        if layer_datum.get('debug_query_size'):
+            logger = logging.getLogger('query')
+            logger.debug('Layer[%r]: %d bytes' %
+                         (layer_datum.get('name'), sys.getsizeof(rows)))
+
         return rows, layer_datum, padded_bounds
     except:
         # If any exception occurs during query execution, close the

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -232,7 +232,7 @@ class ProcessAndFormatData(object):
             start = time.time()
 
             try:
-                formatted_tiles = process_coord(
+                formatted_tiles, extra_data = process_coord(
                     coord, feature_layers, self.post_process_data,
                     self.formats, unpadded_bounds, cut_coords,
                     self.layers_to_format, self.buffer_cfg)
@@ -244,6 +244,7 @@ class ProcessAndFormatData(object):
 
             metadata = data['metadata']
             metadata['timing']['process_seconds'] = time.time() - start
+            metadata['layers'] = extra_data
 
             data = dict(
                 metadata=metadata,
@@ -376,19 +377,23 @@ class SqsQueueWriter(object):
             sqs_timestamp_seconds = sqs_timestamp_millis / 1000.0
             time_in_queue = now - sqs_timestamp_seconds
 
+            size_as_str = repr(metadata['size'])
+
             self.logger.info(
                 '%s '
                 'data(%.2fs) '
                 'proc(%.2fs) '
                 's3(%.2fs) '
                 'ack(%.2fs) '
-                'sqs(%.2fs) ' % (
+                'sqs(%.2fs) '
+                'size(%s) ' % (
                     serialize_coord(coord),
                     timing['fetch_seconds'],
                     timing['process_seconds'],
                     timing['s3_seconds'],
                     timing['ack_seconds'],
                     time_in_queue,
+                    size_as_str,
                 ))
 
         if not saw_sentinel:


### PR DESCRIPTION
This will allow us to collect statistics about which layers contribute most to network traffic, and may help us optimise queries which are returning too much data.

@rmarianski could you review, please?