### PR TITLE
Add support for writing metatiles

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -147,3 +147,13 @@ wof:
     dbname: osm
     user: osm
     password:
+
+# Set the metatile size to 1 to have tilequeue save metatiles to storage rather
+# than individual tiles. This can have major benefits for reducing the number of
+# writes to disk. Set the size to null, or omit the entry, to disable metatile
+# writing and store individual tiles.
+#
+# Only metatiles of size 1 are currently supported, although other sizes may be
+# available in the future.
+metatile:
+  size: null

--- a/tests/test_metatile.py
+++ b/tests/test_metatile.py
@@ -1,0 +1,41 @@
+from tilequeue.metatile import make_metatiles
+from tilequeue.format import json_format, zip_format, topojson_format
+from ModestMaps.Core import Coordinate
+import zipfile
+import StringIO
+import unittest
+
+
+class TestMetatile(unittest.TestCase):
+
+    def test_make_metatiles_single(self):
+        json = "{\"json\":true}"
+        tiles = [dict(tile=json, coord=Coordinate(0, 0, 0),
+                      format=json_format, layer='all')]
+        metatiles = make_metatiles(1, tiles)
+        self.assertEqual(1, len(metatiles))
+        self.assertEqual(Coordinate(0, 0, 0), metatiles[0]['coord'])
+        self.assertEqual('all', metatiles[0]['layer'])
+        self.assertEqual(zip_format, metatiles[0]['format'])
+        buf = StringIO.StringIO(metatiles[0]['tile'])
+        with zipfile.ZipFile(buf, mode='r') as z:
+            self.assertEqual(json, z.open('0/0/0.json').read())
+
+    def test_make_metatiles_multiple(self):
+        json = "{\"json\":true}"
+        tiles = [
+            dict(tile=json, coord=Coordinate(0, 0, 0),
+                 format=json_format, layer='all'),
+            dict(tile=json, coord=Coordinate(0, 0, 0),
+                 format=topojson_format, layer='all'),
+        ]
+
+        metatiles = make_metatiles(1, tiles)
+        self.assertEqual(1, len(metatiles))
+        self.assertEqual(Coordinate(0, 0, 0), metatiles[0]['coord'])
+        self.assertEqual('all', metatiles[0]['layer'])
+        self.assertEqual(zip_format, metatiles[0]['format'])
+        buf = StringIO.StringIO(metatiles[0]['tile'])
+        with zipfile.ZipFile(buf, mode='r') as z:
+            self.assertEqual(json, z.open('0/0/0.json').read())
+            self.assertEqual(json, z.open('0/0/0.topojson').read())

--- a/tests/test_metatile.py
+++ b/tests/test_metatile.py
@@ -39,3 +39,31 @@ class TestMetatile(unittest.TestCase):
         with zipfile.ZipFile(buf, mode='r') as z:
             self.assertEqual(json, z.open('0/0/0.json').read())
             self.assertEqual(json, z.open('0/0/0.topojson').read())
+
+    def test_make_metatiles_multiple_coordinates(self):
+        # we need to be able to handle this so that we can do "cut out"
+        # overzoomed tiles at z>16.
+
+        json = "{\"json\":true}"
+        tiles = [
+            dict(tile=json, coord=Coordinate(17, 123, 456),
+                 format=json_format, layer='all'),
+            dict(tile=json, coord=Coordinate(17, 123, 457),
+                 format=json_format, layer='all'),
+        ]
+
+        metatiles = make_metatiles(1, tiles)
+        self.assertEqual(2, len(metatiles))
+        coords = set([Coordinate(17, 123, 456), Coordinate(17, 123, 457)])
+        for meta in metatiles:
+            self.assertTrue(meta['coord'] in coords)
+            coords.remove(meta['coord'])
+
+            self.assertEqual('all', meta['layer'])
+            self.assertEqual(zip_format, meta['format'])
+            buf = StringIO.StringIO(meta['tile'])
+            with zipfile.ZipFile(buf, mode='r') as z:
+                self.assertEqual(json, z.open('0/0/0.json').read())
+
+        # check all coords were consumed
+        self.assertEqual(0, len(coords))

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -501,7 +501,7 @@ def tilequeue_process(cfg, peripherals):
         cfg.layers_to_format, cfg.buffer_cfg, logger)
 
     s3_storage = S3Storage(processor_queue, s3_store_queue, io_pool,
-                           store, logger)
+                           store, logger, cfg.metatile_size)
 
     thread_sqs_writer_stop = threading.Event()
     sqs_queue_writer = SqsQueueWriter(sqs_queue, s3_store_queue, logger,

--- a/tilequeue/config.py
+++ b/tilequeue/config.py
@@ -105,6 +105,8 @@ class Configuration(object):
 
         self.wof = self.yml.get('wof')
 
+        self.metatile_size = self._cfg('metatile size')
+
     def _cfg(self, yamlkeys_str):
         yamlkeys = yamlkeys_str.split()
         yamlval = self.yml
@@ -191,6 +193,9 @@ def default_yml_config():
             'dbnames': ('osm',),
             'user': 'osm',
             'password': None,
+        },
+        'metatile': {
+            'size': None,
         },
     }
 

--- a/tilequeue/format/__init__.py
+++ b/tilequeue/format/__init__.py
@@ -98,6 +98,9 @@ mvt_format = OutputFormat('MVT', 'mvt', 'application/x-protobuf',
 # also has separate buffer config
 mvtb_format = OutputFormat('MVT Buffered', 'mvtb', 'application/x-protobuf',
                            format_mvt, 4, supports_shapely_geom)
+# package of tiles as a metatile zip
+zip_format = OutputFormat('ZIP Metatile', 'zip', 'application/zip',
+                          None, None, None)
 
 extension_to_format = dict(
     json=json_format,

--- a/tilequeue/metatile.py
+++ b/tilequeue/metatile.py
@@ -1,0 +1,31 @@
+import zipfile
+import StringIO
+from tilequeue.format import zip_format
+
+
+def make_metatiles(size, tiles):
+    """
+    Make a list of metatiles from a list of tiles.
+    """
+
+    assert size == 1, \
+        "Tilequeue only supports metatiles of size one at the moment."
+
+    if len(tiles) == 0:
+        return []
+
+    coord = tiles[0]['coord']
+    layer = tiles[0]['layer']
+
+    buf = StringIO.StringIO()
+    with zipfile.ZipFile(buf, mode='w') as z:
+        for tile in tiles:
+            assert tile['coord'] == coord
+            assert tile['layer'] == layer
+
+            tile_name = '0/0/0.%s' % tile['format'].extension
+            tile_data = tile['tile']
+            z.writestr(tile_name, tile_data)
+
+    return [dict(tile=buf.getvalue(), format=zip_format, coord=coord,
+                 layer=layer)]

--- a/tilequeue/metatile.py
+++ b/tilequeue/metatile.py
@@ -1,11 +1,13 @@
 import zipfile
 import StringIO
+from collections import defaultdict
 from tilequeue.format import zip_format
 
 
-def make_metatiles(size, tiles):
+def make_single_metatile(size, tiles):
     """
-    Make a list of metatiles from a list of tiles.
+    Make a single metatile from a list of tiles all having the same
+    coordinate and layer.
     """
 
     assert size == 1, \
@@ -29,3 +31,21 @@ def make_metatiles(size, tiles):
 
     return [dict(tile=buf.getvalue(), format=zip_format, coord=coord,
                  layer=layer)]
+
+
+def make_metatiles(size, tiles):
+    """
+    Group by coordinates and layers, and make metatiles out of all the tiles
+    which share those properties.
+    """
+
+    groups = defaultdict(list)
+    for tile in tiles:
+        key = (tile['layer'], tile['coord'])
+        groups[key].append(tile)
+
+    metatiles = []
+    for group in groups.itervalues():
+        metatiles.extend(make_single_metatile(size, group))
+
+    return metatiles

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -7,6 +7,7 @@ from tilequeue.tile import coord_marshall_int
 from tilequeue.tile import CoordMessage
 from tilequeue.tile import serialize_coord
 from tilequeue.utils import format_stacktrace_one_line
+from tilequeue.metatile import make_metatiles
 import logging
 import Queue
 import signal

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -264,12 +264,14 @@ class ProcessAndFormatData(object):
 
 class S3Storage(object):
 
-    def __init__(self, input_queue, output_queue, io_pool, store, logger):
+    def __init__(self, input_queue, output_queue, io_pool, store, logger,
+                 metatile_size):
         self.input_queue = input_queue
         self.output_queue = output_queue
         self.io_pool = io_pool
         self.store = store
         self.logger = logger
+        self.metatile_size = metatile_size
 
     def __call__(self, stop):
         saw_sentinel = False
@@ -286,21 +288,7 @@ class S3Storage(object):
             coord = data['coord']
 
             start = time.time()
-            async_jobs = []
-            for formatted_tile in data['formatted_tiles']:
-
-                async_result = self.io_pool.apply_async(
-                    write_tile_if_changed, (
-                        self.store,
-                        formatted_tile['tile'],
-                        # important to use the coord from the
-                        # formatted tile here, because we could have
-                        # cut children tiles that have separate zooms
-                        # too
-                        formatted_tile['coord'],
-                        formatted_tile['format'],
-                        formatted_tile['layer']))
-                async_jobs.append(async_result)
+            async_jobs = self.save_tiles(data['formatted_tiles'])
 
             async_exc_info = None
             n_stored = 0
@@ -346,6 +334,29 @@ class S3Storage(object):
         if not saw_sentinel:
             _force_empty_queue(self.input_queue)
         self.logger.debug('s3 storage stopped')
+
+    def save_tiles(self, tiles):
+        async_jobs = []
+
+        if self.metatile_size:
+            tiles = make_metatiles(self.metatile_size, tiles)
+
+        for tile in tiles:
+
+            async_result = self.io_pool.apply_async(
+                write_tile_if_changed, (
+                    self.store,
+                    tile['tile'],
+                    # important to use the coord from the
+                    # formatted tile here, because we could have
+                    # cut children tiles that have separate zooms
+                    # too
+                    tile['coord'],
+                    tile['format'],
+                    tile['layer']))
+            async_jobs.append(async_result)
+
+        return async_jobs
 
 
 class SqsQueueWriter(object):


### PR DESCRIPTION
If configured (`metatile size` is not `None`), this will write metatiles to storage rather than individual tiles. Each metatile is a zip file containing multiple formats, compatible with [Tapalcatl](https://github.com/tilezen/tapalcatl). Space for future extensions to multiple coordinates has been left, but isn't supported in this change.

I couldn't find anywhere that support for _reading_ metatiles is required in tilequeue at the moment. Is that only needed in tileserver?

@rmarianski, @iandees could you review, please?