### PR TITLE
Allow storing original file formats in addition to metatile zips

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -158,8 +158,12 @@ wof:
 # than individual tiles. This can have major benefits for reducing the number of
 # writes to disk. Set the size to null, or omit the entry, to disable metatile
 # writing and store individual tiles.
-#
-# Only metatiles of size 1 are currently supported, although other sizes may be
-# available in the future.
 metatile:
+  # Only metatiles of size 1 are currently supported, although other sizes may
+  # be available in the future.
   size: null
+
+  # if this is set to true, then tilequeue will write the individual formats in
+  # addition to the metatile. this can be useful when gracefully "cutting over"
+  # to a metatile-based system from an individual format based one.
+  store_metatile_and_originals: false

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -561,7 +561,7 @@ def tilequeue_process(cfg, peripherals):
         cfg.layers_to_format, cfg.buffer_cfg, logger)
 
     s3_storage = S3Storage(processor_queue, s3_store_queue, io_pool,
-                           store, logger, cfg.metatile_size)
+                           store, logger, cfg.metatile_size, cfg.store_orig)
 
     thread_sqs_writer_stop = threading.Event()
     sqs_queue_writer = SqsQueueWriter(sqs_queue, s3_store_queue, logger,

--- a/tilequeue/config.py
+++ b/tilequeue/config.py
@@ -107,6 +107,7 @@ class Configuration(object):
         self.wof = self.yml.get('wof')
 
         self.metatile_size = self._cfg('metatile size')
+        self.store_orig = self._cfg('metatile store_metatile_and_originals')
 
     def _cfg(self, yamlkeys_str):
         yamlkeys = yamlkeys_str.split()
@@ -197,6 +198,7 @@ def default_yml_config():
         },
         'metatile': {
             'size': None,
+            'store_metatile_and_originals': False,
         },
     }
 

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -266,13 +266,14 @@ class ProcessAndFormatData(object):
 class S3Storage(object):
 
     def __init__(self, input_queue, output_queue, io_pool, store, logger,
-                 metatile_size):
+                 metatile_size, store_metatile_and_originals=False):
         self.input_queue = input_queue
         self.output_queue = output_queue
         self.io_pool = io_pool
         self.store = store
         self.logger = logger
         self.metatile_size = metatile_size
+        self.store_metatile_and_originals = store_metatile_and_originals
 
     def __call__(self, stop):
         saw_sentinel = False
@@ -340,7 +341,14 @@ class S3Storage(object):
         async_jobs = []
 
         if self.metatile_size:
-            tiles = make_metatiles(self.metatile_size, tiles)
+            metatiles = make_metatiles(self.metatile_size, tiles)
+
+            # allow the metatile to be stored, or both the metatile
+            # and originals, which allows for a smooth cutover.
+            if self.store_metatile_and_originals:
+                tiles.extend(metatiles)
+            else:
+                tiles = metatiles
 
         for tile in tiles:
 


### PR DESCRIPTION
Added a configuration setting to allow the storage of the original format files in addition to the metatile. This can allow a 'graceful' switch between a non-metatiled configuration and one using metatiles.

@iandees could you review, please?
