### PR TITLE
Add function to read data from a metatile.

### DIFF
--- a/tests/test_metatile.py
+++ b/tests/test_metatile.py
@@ -1,4 +1,4 @@
-from tilequeue.metatile import make_metatiles
+from tilequeue.metatile import make_metatiles, extract_metatile
 from tilequeue.format import json_format, zip_format, topojson_format
 from ModestMaps.Core import Coordinate
 import zipfile
@@ -67,3 +67,13 @@ class TestMetatile(unittest.TestCase):
 
         # check all coords were consumed
         self.assertEqual(0, len(coords))
+
+    def test_extract_metatiles_single(self):
+        json = "{\"json\":true}"
+        tile = dict(tile=json, coord=Coordinate(0, 0, 0),
+                    format=json_format, layer='all')
+        metatiles = make_metatiles(1, [tile])
+        self.assertEqual(1, len(metatiles))
+        buf = StringIO.StringIO(metatiles[0]['tile'])
+        extracted = extract_metatile(1, buf, tile)
+        self.assertEqual(json, extracted)

--- a/tilequeue/metatile.py
+++ b/tilequeue/metatile.py
@@ -49,3 +49,17 @@ def make_metatiles(size, tiles):
         metatiles.extend(make_single_metatile(size, group))
 
     return metatiles
+
+
+def extract_metatile(size, io, tile):
+    """
+    Extract the tile from the metatile given in the file-like object io.
+    """
+
+    assert size == 1, \
+        "Tilequeue only supports metatiles of size one at the moment."
+
+    tile_name = '0/0/0.%s' % tile['format'].extension
+
+    with zipfile.ZipFile(io, mode='r') as zf:
+        return zf.open(tile_name).read()


### PR DESCRIPTION
This isn't needed in tilequeue itself, but is needed in tileserver. However, it is useful to have here along with the rest of the metatile functions to keep that related functionality all in one place.

@iandees could you review, please?