### PR TITLE
Support long zooms

### DIFF
--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -209,3 +209,16 @@ class ZoomToQueueNameMapTest(unittest.TestCase):
         zoom = 7
         with self.assertRaises(AssertionError):
             get_queue(zoom)
+
+    def test_zoom_is_long(self):
+        # the zoom (or row/col) in a Coordinate can be a long simply because
+        # the coordinate it was derived from in unmarshall_coord_int was a
+        # long.
+        from tilequeue.command import make_get_queue_name_for_zoom
+        zoom_queue_map_cfg = {'0-20': 'q1'}
+        queue_names = ['q1']
+        get_queue = make_get_queue_name_for_zoom(
+            zoom_queue_map_cfg, queue_names)
+        zoom = long(7)
+        queue_name = get_queue(zoom)
+        self.assertEqual(queue_name, 'q1')

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -93,7 +93,7 @@ class GetSqsQueueNameForZoom(object):
         self.zoom_queue_table = zoom_queue_table
 
     def __call__(self, zoom):
-        assert isinstance(zoom, int)
+        assert isinstance(zoom, (int, long))
         assert 0 <= zoom <= 20
         result = self.zoom_queue_table.get(zoom)
         assert result is not None, 'No queue name found for zoom: %d' % zoom


### PR DESCRIPTION
Coordinate zooms can sometimes be of type `long` rather than `int` if they are unmarshalled from a `long` integer. This adds `long` to the acceptable types list, and adds a test for that case.

This was causing assertion errors on the background thread in dev.

@iandees could you review, please?