### PR TITLE
Increase topojson scale from 1024 -> 4096

### DIFF
--- a/tilequeue/format/topojson.py
+++ b/tilequeue/format/topojson.py
@@ -37,7 +37,7 @@ def update_arc_indexes(geometry, merged_arcs, old_arcs):
         raise NotImplementedError("Can't do %s geometries" % geometry['type'])
 
 
-def get_transform(bounds, size=1024):
+def get_transform(bounds, size=4096):
     """ Return a TopoJSON transform dictionary and a point-transforming function.
 
         Size is the tile size in pixels and sets the implicit output


### PR DESCRIPTION
Connects to https://github.com/tilezen/vector-datasource/issues/1145

Bumping the scale makes the rendering artifact go away. We'll likely want to revisit the topojson format again with an eye towards returning ogc valid geometries, but this is a quick fix that seems to    help. The downside here is that it may increase the topojson format size across the board for complex geometries.

@zerebubuth, @nvkelso, @iandees could you review please?