### PR TITLE
Use round_fn to specify built-in round function for MVT

### DIFF
--- a/tilequeue/format/mvt.py
+++ b/tilequeue/format/mvt.py
@@ -3,6 +3,10 @@ from mapbox_vector_tile import encode as mvt_encode
 
 
 def encode(fp, feature_layers, coord, bounds_merc):
-    tile = mvt_encode(feature_layers, quantize_bounds=bounds_merc,
-                      on_invalid_geometry=on_invalid_geometry_make_valid)
+    tile = mvt_encode(
+        feature_layers,
+        quantize_bounds=bounds_merc,
+        on_invalid_geometry=on_invalid_geometry_make_valid,
+        round_fn=round,
+    )
     fp.write(tile)


### PR DESCRIPTION
Use the built-in Python rounding function instead of the `Decimal` one.