### PR TITLE
Ignore extra coordinates, e.g: z, in reprojection.

### DIFF
--- a/tests/test_tile.py
+++ b/tests/test_tile.py
@@ -132,3 +132,18 @@ class TestTileGeneration(unittest.TestCase):
         tile_generator = tile_generator_for_single_bounds(bounds, 0, 5)
         tiles = list(tile_generator)
         self.assertEqual(11, len(tiles))
+
+
+class TestReproject(unittest.TestCase):
+
+    def test_reproject(self):
+        from tilequeue.tile import reproject_lnglat_to_mercator
+        coord = reproject_lnglat_to_mercator(0, 0)
+        self.assertAlmostEqual(0, coord[0])
+        self.assertAlmostEqual(0, coord[1])
+
+    def test_reproject_with_z(self):
+        from tilequeue.tile import reproject_lnglat_to_mercator
+        coord = reproject_lnglat_to_mercator(0, 0, 0)
+        self.assertAlmostEqual(0, coord[0])
+        self.assertAlmostEqual(0, coord[1])

--- a/tilequeue/tile.py
+++ b/tilequeue/tile.py
@@ -93,7 +93,7 @@ def coord_to_bounds(coord):
     return bounds
 
 
-def reproject_lnglat_to_mercator(x, y):
+def reproject_lnglat_to_mercator(x, y, *unused_coords):
     return pyproj.transform(latlng_proj, merc_proj, x, y)
 
 


### PR DESCRIPTION
More than two coordinates are allowed by the GeoJSON spec, and this was causing some errors in the WOF import logs because the reprojection function assumed that there were only two. This fixes it by allowing any number of extra coordinates, which are all ignored.

@rmarianski, @iandees please could you review?