### PR TITLE
Compare ZIP file ignoring metadata

### DIFF
--- a/tests/test_metatile.py
+++ b/tests/test_metatile.py
@@ -79,7 +79,7 @@ class TestMetatile(unittest.TestCase):
         self.assertEqual(json, extracted)
 
     def test_metatile_file_timing(self):
-        from time import sleep, gmtime, time
+        from time import gmtime, time
         from tilequeue.metatile import metatiles_are_equal
 
         # tilequeue's "GET before PUT" optimisation relies on being able to

--- a/tests/test_metatile.py
+++ b/tests/test_metatile.py
@@ -77,3 +77,27 @@ class TestMetatile(unittest.TestCase):
         buf = StringIO.StringIO(metatiles[0]['tile'])
         extracted = extract_metatile(1, buf, tile)
         self.assertEqual(json, extracted)
+
+    def test_metatile_file_timing(self):
+        from time import sleep, gmtime, time
+        from tilequeue.metatile import metatiles_are_equal
+
+        # tilequeue's "GET before PUT" optimisation relies on being able to
+        # fetch a tile from S3 and compare it to the one that was just
+        # generated. to do this, we should try to make the tiles as similar
+        # as possible across multiple runs.
+
+        json = "{\"json\":true}"
+        tiles = [dict(tile=json, coord=Coordinate(0, 0, 0),
+                      format=json_format, layer='all')]
+
+        when_will_then_be_now = 10
+        t = time()
+        now = gmtime(t)[0:6]
+        then = gmtime(t - when_will_then_be_now)[0:6]
+
+        metatile_1 = make_metatiles(1, tiles, then)
+        metatile_2 = make_metatiles(1, tiles, now)
+
+        self.assertTrue(metatiles_are_equal(
+            metatile_1[0]['tile'], metatile_2[0]['tile']))

--- a/tests/test_metatile.py
+++ b/tests/test_metatile.py
@@ -2,7 +2,7 @@ from tilequeue.metatile import make_metatiles, extract_metatile
 from tilequeue.format import json_format, zip_format, topojson_format
 from ModestMaps.Core import Coordinate
 import zipfile
-import StringIO
+import cStringIO as StringIO
 import unittest
 
 

--- a/tilequeue/metatile.py
+++ b/tilequeue/metatile.py
@@ -1,7 +1,8 @@
 import zipfile
-import StringIO
+import cStringIO as StringIO
 from collections import defaultdict
 from tilequeue.format import zip_format
+from time import gmtime
 
 
 def make_single_metatile(size, tiles, date_time=None):
@@ -19,7 +20,6 @@ def make_single_metatile(size, tiles, date_time=None):
         return []
 
     if date_time is None:
-        from time import gmtime
         date_time = gmtime()[0:6]
 
     coord = tiles[0]['coord']

--- a/tilequeue/metatile.py
+++ b/tilequeue/metatile.py
@@ -4,10 +4,12 @@ from collections import defaultdict
 from tilequeue.format import zip_format
 
 
-def make_single_metatile(size, tiles):
+def make_single_metatile(size, tiles, date_time=None):
     """
     Make a single metatile from a list of tiles all having the same
-    coordinate and layer.
+    coordinate and layer. Set date_time to a 6-tuple of (year, month,
+    day, hour, minute, second) to set the timestamp for members.
+    Otherwise the current wall clock time is used.
     """
 
     assert size == 1, \
@@ -15,6 +17,10 @@ def make_single_metatile(size, tiles):
 
     if len(tiles) == 0:
         return []
+
+    if date_time is None:
+        from time import gmtime
+        date_time = gmtime()[0:6]
 
     coord = tiles[0]['coord']
     layer = tiles[0]['layer']
@@ -27,16 +33,19 @@ def make_single_metatile(size, tiles):
 
             tile_name = '0/0/0.%s' % tile['format'].extension
             tile_data = tile['tile']
-            z.writestr(tile_name, tile_data)
+            info = zipfile.ZipInfo(tile_name, date_time)
+            z.writestr(info, tile_data)
 
     return [dict(tile=buf.getvalue(), format=zip_format, coord=coord,
                  layer=layer)]
 
 
-def make_metatiles(size, tiles):
+def make_metatiles(size, tiles, date_time = None):
     """
     Group by coordinates and layers, and make metatiles out of all the tiles
-    which share those properties.
+    which share those properties. Provide a 6-tuple date_time to set the
+    timestamp on each tile within the metatile, or leave it as None to use
+    the current time.
     """
 
     groups = defaultdict(list)
@@ -46,7 +55,7 @@ def make_metatiles(size, tiles):
 
     metatiles = []
     for group in groups.itervalues():
-        metatiles.extend(make_single_metatile(size, group))
+        metatiles.extend(make_single_metatile(size, group, date_time))
 
     return metatiles
 
@@ -63,3 +72,52 @@ def extract_metatile(size, io, tile):
 
     with zipfile.ZipFile(io, mode='r') as zf:
         return zf.open(tile_name).read()
+
+
+def _metatile_contents_equal(zip_1, zip_2):
+    """
+    Given two open zip files as arguments, this returns True if the zips
+    both contain the same set of files, having the same names, and each
+    file within the zip is byte-wise identical to the one with the same
+    name in the other zip.
+    """
+
+    names_1 = set(zip_1.namelist())
+    names_2 = set(zip_2.namelist())
+
+    if names_1 != names_2:
+        return False
+
+    for n in names_1:
+        bytes_1 = zip_1.read(n)
+        bytes_2 = zip_2.read(n)
+
+        if bytes_1 != bytes_2:
+            return False
+
+    return True
+
+
+def metatiles_are_equal(tile_data_1, tile_data_2):
+    """
+    Return True if the two tiles are both zipped metatiles and contain the
+    same set of files with the same contents. This ignores the timestamp of
+    the individual files in the zip files, as well as their order or any
+    other metadata.
+    """
+
+    try:
+        buf_1 = StringIO.StringIO(tile_data_1)
+        buf_2 = StringIO.StringIO(tile_data_2)
+
+        with zipfile.ZipFile(buf_1, mode='r') as zip_1:
+            with zipfile.ZipFile(buf_2, mode='r') as zip_2:
+                return _metatile_contents_equal(zip_1, zip_2)
+
+    except (StandardError, zipfile.BadZipFile, zipfile.LargeZipFile):
+        # errors, such as files not being proper zip files, or missing
+        # some attributes or contents that we expect, are treated as not
+        # equal.
+        pass
+
+    return False

--- a/tilequeue/metatile.py
+++ b/tilequeue/metatile.py
@@ -40,7 +40,7 @@ def make_single_metatile(size, tiles, date_time=None):
                  layer=layer)]
 
 
-def make_metatiles(size, tiles, date_time = None):
+def make_metatiles(size, tiles, date_time=None):
     """
     Group by coordinates and layers, and make metatiles out of all the tiles
     which share those properties. Provide a 6-tuple date_time to set the

--- a/tilequeue/store.py
+++ b/tilequeue/store.py
@@ -4,6 +4,8 @@ from boto import connect_s3
 from boto.s3.bucket import Bucket
 import md5
 import os
+from tilequeue.metatile import metatiles_are_equal
+from tilequeue.format import zip_format
 
 
 def calc_hash(s):
@@ -152,10 +154,7 @@ def tiles_are_equal(tile_data_1, tile_data_2, fmt):
     metadata such as timestamps and doesn't control file ordering.
     """
 
-    from tilequeue.format import zip_format
-
     if fmt and fmt == zip_format:
-        from tilequeue.metatile import metatiles_are_equal
         return metatiles_are_equal(tile_data_1, tile_data_2)
 
     else:


### PR DESCRIPTION
When comparing zip files to see if the tile already in storage is the same as the one just generated, ignore the timestamp and archive file order, as these are likely to change between two renders. Instead, all we care about is that they contain the same set of files and that those files have identical content. 

Connects to #152.

@rmarianski, @iandees could you review, please?