### PR TITLE
Return a better error for invalid dates

### DIFF
--- a/tilequeue/wof.py
+++ b/tilequeue/wof.py
@@ -327,13 +327,26 @@ def create_neighbourhood_from_json(json_data, neighbourhood_meta):
     edtf_cessation = _normalize_edtf(props.get('edtf:cessation'))
     edtf_deprecated = _normalize_edtf(props.get('edtf:deprecated'))
 
+    # check that the dates are valid first to return back a better error
+    inception_earliest = edtf_inception.date_earliest()
+    cessation_latest = edtf_cessation.date_latest()
+    deprecated_latest = edtf_deprecated.date_latest()
+    if inception_earliest is None:
+        return failure('invalid edtf:inception: %s' %
+                       props.get('edtf:inception'))
+    if cessation_latest is None:
+        return failure('invalid edtf:cessation: %s' %
+                       props.get('edtf:cessation'))
+    if deprecated_latest is None:
+        return failure('invalid edtf:deprecated: %s' %
+                       props.get('edtf:deprecated'))
+
     # the 'edtf:inception' property gives us approximately the former and we
     # take the earliest date it could mean. the 'edtf:cessation' and
     # 'edtf:deprecated' would both stop the item showing, so we take the
     # earliest of each's latest possible date.
-    inception = edtf_inception.date_earliest()
-    cessation = min(edtf_cessation.date_latest(),
-                    edtf_deprecated.date_latest())
+    inception = inception_earliest
+    cessation = min(cessation_latest, deprecated_latest)
 
     # grab any names in other languages
     lang_suffix_size = len('_preferred')


### PR DESCRIPTION
When we get invalid dates, we can have the edtf date api return back `None` for earliest/latest dates. This adds a check to guard against that, and return back a better error message in this case. Otherwise, the `min` or something else downstream will raise a general error when it's first used.