### PR TITLE
``tilequeue.store.TileDirectory`` must write files *atomically*

### DIFF
--- a/tilequeue/store.py
+++ b/tilequeue/store.py
@@ -174,11 +174,18 @@ class TileDirectory(object):
             random.randint(1,1000000)
         )
 
-        with open(swap_file_path, 'w') as tile_fp:
-            tile_fp.write(tile_data)
+        try:
+            with open(swap_file_path, 'w') as tile_fp:
+                tile_fp.write(tile_data)
 
-        # write file as atomic operation
-        os_replace(swap_file_path, file_path)
+            # write file as atomic operation
+            os_replace(swap_file_path, file_path)
+        except Exception as e:
+            try:
+                os.remove(swap_file_path)
+            except OSError:
+                pass
+            raise e
 
     def read_tile(self, coord, format, layer):
         file_path = make_file_path(self.base_path, coord, layer,


### PR DESCRIPTION
``tilequeue.store.TileDirectory`` must write files *atomicly* ..


problem description
-------------------------

* if server process will stopped suddenly -- cached must be protected from corruption. ``Gunicorn`` may kill process (any time) if timer of timeout of request elapsed

* cached must not able to read when it is not yet complete written.  ``Gunicorn`` runs several concurrent processes with one store directory.


patch details
----------------

introduced function ``os_replace(src, dst)`` for *unix-style* atomically file writing