### PR TITLE
Use nominal zoom to control post-processing zoom

### DIFF
--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -26,8 +26,8 @@ class TestProcess(unittest.TestCase):
         formats = [json_format]
 
         tiles, extra = process_coord(
-            coord, feature_layers, post_process_data, formats, unpadded_bounds,
-            cut_coords, buffer_cfg)
+            coord, coord.zoom, feature_layers, post_process_data, formats,
+            unpadded_bounds, cut_coords, buffer_cfg)
 
         return tiles
 
@@ -57,8 +57,8 @@ class TestProcess(unittest.TestCase):
         buffer_cfg = {}
 
         tiles, extra = process_coord(
-            coord, feature_layers, post_process_data, formats, unpadded_bounds,
-            cut_coords, buffer_cfg)
+            coord, coord.zoom, feature_layers, post_process_data, formats,
+            unpadded_bounds, cut_coords, buffer_cfg)
 
         self.assertEqual([], tiles)
         self.assertEqual({'size': {}}, extra)

--- a/tilequeue/format/OSciMap4/TagRewrite/__init__.py
+++ b/tilequeue/format/OSciMap4/TagRewrite/__init__.py
@@ -10,7 +10,7 @@ import logging
 # aeroway=>aerobridge
 # leisure=>natural_reserve
 
-def fixTag(tag, zoomlevel):
+def fixTag(tag):
     drop = False
      
     if tag[1] is None:

--- a/tilequeue/format/__init__.py
+++ b/tilequeue/format/__init__.py
@@ -31,7 +31,7 @@ class OutputFormat(object):
 
     def format_tile(self, tile_data_file, feature_layers, coord, bounds_merc,
                     bounds_lnglat):
-        self.format_fn(tile_data_file, feature_layers, coord, bounds_merc,
+        self.format_fn(tile_data_file, feature_layers, coord.zoom, bounds_merc,
                        bounds_lnglat)
 
 
@@ -47,21 +47,21 @@ def convert_feature_layers_to_dict(feature_layers):
 
 
 # consistent facade around all formatters that we use
-def format_json(fp, feature_layers, coord, bounds_merc, bounds_lnglat):
+def format_json(fp, feature_layers, zoom, bounds_merc, bounds_lnglat):
     if len(feature_layers) == 1:
-        json_encode_single_layer(fp, feature_layers[0]['features'], coord.zoom)
+        json_encode_single_layer(fp, feature_layers[0]['features'], zoom)
         return
     else:
         features_by_layer = convert_feature_layers_to_dict(feature_layers)
         json_encode_multiple_layers(fp, features_by_layer, coord.zoom)
 
 
-def format_topojson(fp, feature_layers, coord, bounds_merc, bounds_lnglat):
+def format_topojson(fp, feature_layers, zoom, bounds_merc, bounds_lnglat):
     features_by_layer = convert_feature_layers_to_dict(feature_layers)
     topojson_encode(fp, features_by_layer, bounds_lnglat)
 
 
-def format_mvt(fp, feature_layers, coord, bounds_merc, bounds_lnglat):
+def format_mvt(fp, feature_layers, zoom, bounds_merc, bounds_lnglat):
     mvt_layers = []
     for feature_layer in feature_layers:
         mvt_features = []
@@ -80,7 +80,7 @@ def format_mvt(fp, feature_layers, coord, bounds_merc, bounds_lnglat):
     mvt_encode(fp, mvt_layers, bounds_merc)
 
 
-def format_vtm(fp, feature_layers, coord, bounds_merc, bounds_lnglat):
+def format_vtm(fp, feature_layers, zoom, bounds_merc, bounds_lnglat):
     vtm_encode(fp, feature_layers)
 
 

--- a/tilequeue/format/__init__.py
+++ b/tilequeue/format/__init__.py
@@ -81,7 +81,7 @@ def format_mvt(fp, feature_layers, coord, bounds_merc, bounds_lnglat):
 
 
 def format_vtm(fp, feature_layers, coord, bounds_merc, bounds_lnglat):
-    vtm_encode(fp, feature_layers, coord)
+    vtm_encode(fp, feature_layers, coord.zoom)
 
 
 supports_shapely_geom = True

--- a/tilequeue/format/__init__.py
+++ b/tilequeue/format/__init__.py
@@ -81,7 +81,7 @@ def format_mvt(fp, feature_layers, coord, bounds_merc, bounds_lnglat):
 
 
 def format_vtm(fp, feature_layers, coord, bounds_merc, bounds_lnglat):
-    vtm_encode(fp, feature_layers, coord.zoom)
+    vtm_encode(fp, feature_layers)
 
 
 supports_shapely_geom = True

--- a/tilequeue/format/__init__.py
+++ b/tilequeue/format/__init__.py
@@ -29,9 +29,9 @@ class OutputFormat(object):
     def __eq__(self, other):
         return self.extension == other.extension
 
-    def format_tile(self, tile_data_file, feature_layers, coord, bounds_merc,
+    def format_tile(self, tile_data_file, feature_layers, zoom, bounds_merc,
                     bounds_lnglat):
-        self.format_fn(tile_data_file, feature_layers, coord.zoom, bounds_merc,
+        self.format_fn(tile_data_file, feature_layers, zoom, bounds_merc,
                        bounds_lnglat)
 
 

--- a/tilequeue/format/__init__.py
+++ b/tilequeue/format/__init__.py
@@ -77,7 +77,7 @@ def format_mvt(fp, feature_layers, coord, bounds_merc, bounds_lnglat):
             features=mvt_features,
         )
         mvt_layers.append(mvt_layer)
-    mvt_encode(fp, mvt_layers, coord, bounds_merc)
+    mvt_encode(fp, mvt_layers, bounds_merc)
 
 
 def format_vtm(fp, feature_layers, coord, bounds_merc, bounds_lnglat):

--- a/tilequeue/format/__init__.py
+++ b/tilequeue/format/__init__.py
@@ -53,7 +53,7 @@ def format_json(fp, feature_layers, zoom, bounds_merc, bounds_lnglat):
         return
     else:
         features_by_layer = convert_feature_layers_to_dict(feature_layers)
-        json_encode_multiple_layers(fp, features_by_layer, coord.zoom)
+        json_encode_multiple_layers(fp, features_by_layer, zoom)
 
 
 def format_topojson(fp, feature_layers, zoom, bounds_merc, bounds_lnglat):

--- a/tilequeue/format/mvt.py
+++ b/tilequeue/format/mvt.py
@@ -2,7 +2,7 @@ from mapbox_vector_tile.encoder import on_invalid_geometry_make_valid
 from mapbox_vector_tile import encode as mvt_encode
 
 
-def encode(fp, feature_layers, coord, bounds_merc):
+def encode(fp, feature_layers, bounds_merc):
     tile = mvt_encode(
         feature_layers,
         quantize_bounds=bounds_merc,

--- a/tilequeue/format/vtm.py
+++ b/tilequeue/format/vtm.py
@@ -22,12 +22,12 @@ extents = 4096
 padding = 5
 
 
-def encode(file, features, zoom, layer_name=''):
+def encode(file, features, layer_name=''):
         layer_name = layer_name or ''
         tile = VectorTile(extents)
 
         for feature in features:
-            tile.addFeature(feature, zoom, layer_name)
+            tile.addFeature(feature, layer_name)
 
         tile.complete()
 
@@ -36,7 +36,7 @@ def encode(file, features, zoom, layer_name=''):
         file.write(data)
 
 
-def merge(file, feature_layers, zoom):
+def merge(file, feature_layers):
     ''' Retrieve a list of OSciMap4 tile responses and merge them into one.
 
         get_tiles() retrieves data and performs basic integrity checks.
@@ -44,7 +44,7 @@ def merge(file, feature_layers, zoom):
     tile = VectorTile(extents)
 
     for layer in feature_layers:
-        tile.addFeatures(layer['features'], zoom, layer['name'])
+        tile.addFeatures(layer['features'], layer['name'])
 
     tile.complete()
 
@@ -84,11 +84,11 @@ class VectorTile:
         if self.cur_val - attrib_offset > 0:
             self.out.num_vals = self.cur_val - attrib_offset
 
-    def addFeatures(self, features, zoom, this_layer):
+    def addFeatures(self, features, this_layer):
         for feature in features:
-            self.addFeature(feature, zoom, this_layer)
+            self.addFeature(feature, this_layer)
 
-    def addFeature(self, row, zoom, this_layer):
+    def addFeature(self, row, this_layer):
         geom = self.geomencoder
         tags = []
 
@@ -115,7 +115,7 @@ class VectorTile:
                 layer = self.getLayer(tag[1])
                 continue
 
-            tag = fixTag(tag, zoom)
+            tag = fixTag(tag)
 
             if tag is None:
                 continue

--- a/tilequeue/format/vtm.py
+++ b/tilequeue/format/vtm.py
@@ -22,12 +22,12 @@ extents = 4096
 padding = 5
 
 
-def encode(file, features, coord, layer_name=''):
+def encode(file, features, zoom, layer_name=''):
         layer_name = layer_name or ''
         tile = VectorTile(extents)
 
         for feature in features:
-            tile.addFeature(feature, coord, layer_name)
+            tile.addFeature(feature, zoom, layer_name)
 
         tile.complete()
 
@@ -36,7 +36,7 @@ def encode(file, features, coord, layer_name=''):
         file.write(data)
 
 
-def merge(file, feature_layers, coord):
+def merge(file, feature_layers, zoom):
     ''' Retrieve a list of OSciMap4 tile responses and merge them into one.
 
         get_tiles() retrieves data and performs basic integrity checks.
@@ -44,7 +44,7 @@ def merge(file, feature_layers, coord):
     tile = VectorTile(extents)
 
     for layer in feature_layers:
-        tile.addFeatures(layer['features'], coord, layer['name'])
+        tile.addFeatures(layer['features'], zoom, layer['name'])
 
     tile.complete()
 
@@ -84,11 +84,11 @@ class VectorTile:
         if self.cur_val - attrib_offset > 0:
             self.out.num_vals = self.cur_val - attrib_offset
 
-    def addFeatures(self, features, coord, this_layer):
+    def addFeatures(self, features, zoom, this_layer):
         for feature in features:
-            self.addFeature(feature, coord, this_layer)
+            self.addFeature(feature, zoom, this_layer)
 
-    def addFeature(self, row, coord, this_layer):
+    def addFeature(self, row, zoom, this_layer):
         geom = self.geomencoder
         tags = []
 
@@ -115,7 +115,7 @@ class VectorTile:
                 layer = self.getLayer(tag[1])
                 continue
 
-            tag = fixTag(tag, coord.zoom)
+            tag = fixTag(tag, zoom)
 
             if tag is None:
                 continue

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -267,13 +267,7 @@ def _create_formatted_tile(
 
 
 def _process_feature_layers(
-        feature_layers, coord, post_process_data, unpadded_bounds):
-
-    # the nominal zoom is the "display scale" zoom, which may not correspond
-    # to actual tile coordinates in future versions of the code. it just
-    # becomes a measure of the scale between tile features and intended
-    # display size.
-    nominal_zoom = coord.zoom
+        feature_layers, nominal_zoom, post_process_data, unpadded_bounds):
 
     processed_feature_layers = []
     # filter, and then transform each layer as necessary
@@ -372,10 +366,16 @@ def _cut_child_tiles(
 # each formatter. this is the entry point from the worker process
 def process_coord(coord, feature_layers, post_process_data, formats,
                   unpadded_bounds, cut_coords, buffer_cfg, scale=4096):
+    # the nominal zoom is the "display scale" zoom, which may not correspond
+    # to actual tile coordinates in future versions of the code. it just
+    # becomes a measure of the scale between tile features and intended
+    # display size.
+    nominal_zoom = coord.zoom
+
     feature_layers, extra_data = _preprocess_data(feature_layers)
 
     processed_feature_layers = _process_feature_layers(
-        feature_layers, coord, post_process_data, unpadded_bounds)
+        feature_layers, nominal_zoom, post_process_data, unpadded_bounds)
 
     coord_formatted_tiles = _format_feature_layers(
         processed_feature_layers, coord, formats, unpadded_bounds, scale,

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -364,14 +364,14 @@ def _cut_child_tiles(
 # given a coord and the raw feature layers results from the database,
 # filter, transform, sort, post-process and then format according to
 # each formatter. this is the entry point from the worker process
-def process_coord(coord, feature_layers, post_process_data, formats,
-                  unpadded_bounds, cut_coords, buffer_cfg, scale=4096):
-    # the nominal zoom is the "display scale" zoom, which may not correspond
-    # to actual tile coordinates in future versions of the code. it just
-    # becomes a measure of the scale between tile features and intended
-    # display size.
-    nominal_zoom = coord.zoom
-
+#
+# the nominal zoom is the "display scale" zoom, which may not correspond
+# to actual tile coordinates in future versions of the code. it just
+# becomes a measure of the scale between tile features and intended
+# display size.
+def process_coord(coord, nominal_zoom, feature_layers, post_process_data,
+                  formats, unpadded_bounds, cut_coords, buffer_cfg,
+                  scale=4096):
     feature_layers, extra_data = _preprocess_data(feature_layers)
 
     processed_feature_layers = _process_feature_layers(

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -258,7 +258,7 @@ def _create_formatted_tile(
 
     # use the formatter to generate the tile
     tile_data_file = StringIO()
-    format.format_tile(tile_data_file, transformed_feature_layers, coord,
+    format.format_tile(tile_data_file, transformed_feature_layers, coord.zoom,
                        unpadded_bounds, unpadded_bounds_lnglat)
     tile = tile_data_file.getvalue()
 

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -253,7 +253,7 @@ def _create_formatted_tile(
 
     # perform format specific transformations
     transformed_feature_layers = transform_feature_layers_shape(
-        feature_layers, format, scale, unpadded_bounds, coord,
+        feature_layers, format, scale, unpadded_bounds,
         meters_per_pixel_dim, buffer_cfg)
 
     # use the formatter to generate the tile

--- a/tilequeue/transform.py
+++ b/tilequeue/transform.py
@@ -97,7 +97,7 @@ def calc_buffered_bounds(
 
 
 def transform_feature_layers_shape(
-        feature_layers, format, scale, unpadded_bounds, coord,
+        feature_layers, format, scale, unpadded_bounds,
         meters_per_pixel_dim, buffer_cfg):
     if format in (json_format, topojson_format):
         transform_fn = apply_to_all_coords(mercator_point_to_lnglat)

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -232,9 +232,9 @@ class ProcessAndFormatData(object):
 
             try:
                 formatted_tiles, extra_data = process_coord(
-                    coord, feature_layers, self.post_process_data,
-                    self.formats, unpadded_bounds, cut_coords,
-                    self.buffer_cfg)
+                    coord, nominal_zoom, feature_layers,
+                    self.post_process_data, self.formats, unpadded_bounds,
+                    cut_coords, self.buffer_cfg)
             except:
                 stacktrace = format_stacktrace_one_line()
                 self.logger.error('Error processing: %s - %s' % (

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -125,6 +125,7 @@ class DataFetch(object):
                 break
 
             coord = data['coord']
+            nominal_zoom = coord.zoom
 
             start = time.time()
 
@@ -184,6 +185,7 @@ class DataFetch(object):
                 feature_layers=fetch_data['feature_layers'],
                 unpadded_bounds=fetch_data['unpadded_bounds'],
                 cut_coords=cut_coords,
+                nominal_zoom=nominal_zoom,
             )
 
             while not _non_blocking_put(self.output_queue, data):
@@ -227,6 +229,7 @@ class ProcessAndFormatData(object):
             feature_layers = data['feature_layers']
             unpadded_bounds = data['unpadded_bounds']
             cut_coords = data['cut_coords']
+            nominal_zoom = data['nominal_zoom']
 
             start = time.time()
 


### PR DESCRIPTION
This removes a bunch of places where we were passing around a `coord`, but only needed a `zoom`. Removing the coordinate allows us to introduce an explicit `nominal_zoom` which controls the zoom level at which the post-processing runs, and may be different from the zoom level associated with the address of the tile and its bounds.

@rmarianski could you review, please?