### PR TITLE
Query the DataFetcher at nominal zoom

### DIFF
--- a/tilequeue/query.py
+++ b/tilequeue/query.py
@@ -1,7 +1,6 @@
 from psycopg2.extras import RealDictCursor
 from tilequeue.postgresql import DBAffinityConnectionsNoLimit
 from tilequeue.tile import calc_meters_per_pixel_dim
-from tilequeue.tile import coord_to_mercator_bounds
 from tilequeue.transform import calculate_padded_bounds
 import sys
 
@@ -161,11 +160,9 @@ class DataFetcher(object):
             self.dbnames, self.conn_info)
         self.n_conn = n_conn
 
-    def __call__(self, coord, layer_data=None):
+    def __call__(self, zoom, unpadded_bounds, layer_data=None):
         if layer_data is None:
             layer_data = self.layer_data
-        zoom = coord.zoom
-        unpadded_bounds = coord_to_mercator_bounds(coord)
 
         sql_conns = self.sql_conn_pool.get_conns(self.n_conn)
         try:

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -4,6 +4,7 @@ from tilequeue.process import process_coord
 from tilequeue.store import write_tile_if_changed
 from tilequeue.tile import coord_children_range
 from tilequeue.tile import coord_marshall_int
+from tilequeue.tile import coord_to_mercator_bounds
 from tilequeue.tile import serialize_coord
 from tilequeue.utils import format_stacktrace_one_line
 from tilequeue.metatile import make_metatiles
@@ -126,11 +127,12 @@ class DataFetch(object):
 
             coord = data['coord']
             nominal_zoom = coord.zoom
+            unpadded_bounds = coord_to_mercator_bounds(coord)
 
             start = time.time()
 
             try:
-                fetch_data = self.fetcher(coord)
+                fetch_data = self.fetcher(nominal_zoom, unpadded_bounds)
             except:
                 exc_type, exc_value, exc_traceback = sys.exc_info()
                 stacktrace = format_stacktrace_one_line(


### PR DESCRIPTION
This makes it easier to separate the zoom used for querying and postprocessing, which I've been calling `nominal_zoom` but would perhaps be better called "display zoom", from the zoom level used to indicate the spatial extent of the tile.
