### PR TITLE
Add support for 2x2 metatile

### DIFF
--- a/tests/test_metatile.py
+++ b/tests/test_metatile.py
@@ -47,6 +47,8 @@ class TestMetatile(unittest.TestCase):
 
         json = "{\"json\":true}"
         tiles = [
+            # NOTE: coordinates are (y, x, z), possibly the most confusing
+            # possible permutation.
             dict(tile=json, coord=Coordinate(123, 456, 17),
                  format=json_format, layer='all'),
             dict(tile=json, coord=Coordinate(123, 457, 17),
@@ -57,6 +59,7 @@ class TestMetatile(unittest.TestCase):
         self.assertEqual(1, len(metatiles))
         meta = metatiles[0]
 
+        # NOTE: Coordinate(y, x, z)
         coord = Coordinate(61, 228, 16)
         self.assertEqual(meta['coord'], coord)
 
@@ -64,7 +67,7 @@ class TestMetatile(unittest.TestCase):
         self.assertEqual(zip_format, meta['format'])
         buf = StringIO.StringIO(meta['tile'])
         with zipfile.ZipFile(buf, mode='r') as z:
-            self.assertEqual(json, z.open('1/1/0.json').read())
+            self.assertEqual(json, z.open('1/0/1.json').read())
             self.assertEqual(json, z.open('1/1/1.json').read())
 
     def test_extract_metatiles_single(self):

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -559,7 +559,7 @@ def tilequeue_process(cfg, peripherals):
 
     data_fetch = DataFetch(
         feature_fetcher, sqs_input_queue, sql_data_fetch_queue, io_pool,
-        peripherals.redis_cache_index, logger)
+        peripherals.redis_cache_index, logger, cfg.metatile_size)
 
     data_processor = ProcessAndFormatData(
         post_process_data, formats, sql_data_fetch_queue, processor_queue,

--- a/tilequeue/metatile.py
+++ b/tilequeue/metatile.py
@@ -109,7 +109,7 @@ def make_metatiles(size, tiles, date_time=None):
 
     metatiles = []
     for group in groups.itervalues():
-        parent = _parent_tile([t['coord'] for t in group])
+        parent = _parent_tile(t['coord'] for t in group)
         metatiles.extend(make_multi_metatile(parent, group, date_time))
 
     return metatiles

--- a/tilequeue/metatile.py
+++ b/tilequeue/metatile.py
@@ -49,7 +49,7 @@ def make_multi_metatile(parent, tiles, date_time=None):
                 "column is not."
 
             tile_name = '%d/%d/%d.%s' % \
-                (delta_z, delta_row, delta_column, tile['format'].extension)
+                (delta_z, delta_column, delta_row, tile['format'].extension)
             tile_data = tile['tile']
             info = zipfile.ZipInfo(tile_name, date_time)
             z.writestr(info, tile_data)

--- a/tilequeue/metatile.py
+++ b/tilequeue/metatile.py
@@ -5,16 +5,16 @@ from tilequeue.format import zip_format
 from time import gmtime
 
 
-def make_single_metatile(size, tiles, date_time=None):
+def make_multi_metatile(parent, tiles, date_time=None):
     """
-    Make a single metatile from a list of tiles all having the same
-    coordinate and layer. Set date_time to a 6-tuple of (year, month,
-    day, hour, minute, second) to set the timestamp for members.
-    Otherwise the current wall clock time is used.
+    Make a metatile containing a list of tiles all having the same layer,
+    with coordinates relative to the given parent. Set date_time to a 6-tuple
+    of (year, month, day, hour, minute, second) to set the timestamp for
+    members. Otherwise the current wall clock time is used.
     """
 
-    assert size == 1, \
-        "Tilequeue only supports metatiles of size one at the moment."
+    assert parent is not None, \
+        "Parent tile must be provided and not None to make a metatile."
 
     if len(tiles) == 0:
         return []
@@ -22,40 +22,95 @@ def make_single_metatile(size, tiles, date_time=None):
     if date_time is None:
         date_time = gmtime()[0:6]
 
-    coord = tiles[0]['coord']
     layer = tiles[0]['layer']
 
     buf = StringIO.StringIO()
     with zipfile.ZipFile(buf, mode='w') as z:
         for tile in tiles:
-            assert tile['coord'] == coord
             assert tile['layer'] == layer
 
-            tile_name = '0/0/0.%s' % tile['format'].extension
+            coord = tile['coord']
+
+            # change in zoom level from parent to coord. since parent should
+            # be a parent, its zoom should always be equal or smaller to that
+            # of coord.
+            delta_z = coord.zoom - parent.zoom
+            assert delta_z >= 0, "Coordinates must be descendents of parent"
+
+            # change in row/col coordinates are relative to the upper left
+            # coordinate at that zoom. both should be positive.
+            delta_row = coord.row - (int(parent.row) << delta_z)
+            delta_column = coord.column - (int(parent.column) << delta_z)
+            assert delta_row >= 0, \
+                "Coordinates must be contained by their parent, but " + \
+                "row is not."
+            assert delta_column >= 0, \
+                "Coordinates must be contained by their parent, but " + \
+                "column is not."
+
+            tile_name = '%d/%d/%d.%s' % \
+                (delta_z, delta_row, delta_column, tile['format'].extension)
             tile_data = tile['tile']
             info = zipfile.ZipInfo(tile_name, date_time)
             z.writestr(info, tile_data)
 
-    return [dict(tile=buf.getvalue(), format=zip_format, coord=coord,
+    return [dict(tile=buf.getvalue(), format=zip_format, coord=parent,
                  layer=layer)]
+
+
+def _common_parent(a, b):
+    """
+    Find the common parent tile of both a and b. The common parent is the tile
+    at the highest zoom which both a and b can be transformed into by lowering
+    their zoom levels.
+    """
+
+    if a.zoom < b.zoom:
+        a = a.zoomTo(b.zoom).container()
+
+    elif a.zoom > b.zoom:
+        b = b.zoomTo(a.zoom).container()
+
+    while a.row != b.row or a.column != b.column:
+        a = a.zoomBy(-1).container()
+        b = b.zoomBy(-1).container()
+
+    # by this point a == b.
+    return a
+
+
+def _parent_tile(tiles):
+    """
+    Find the common parent tile for a sequence of tiles.
+    """
+    parent = None
+    for t in tiles:
+        if parent is None:
+            parent = t
+
+        else:
+            parent = _common_parent(parent, t)
+
+    return parent
 
 
 def make_metatiles(size, tiles, date_time=None):
     """
-    Group by coordinates and layers, and make metatiles out of all the tiles
-    which share those properties. Provide a 6-tuple date_time to set the
-    timestamp on each tile within the metatile, or leave it as None to use
-    the current time.
+    Group by layers, and make metatiles out of all the tiles which share those
+    properties relative to the "top level" tile which is parent of them all.
+    Provide a 6-tuple date_time to set the timestamp on each tile within the
+    metatile, or leave it as None to use the current time.
     """
 
     groups = defaultdict(list)
     for tile in tiles:
-        key = (tile['layer'], tile['coord'])
+        key = tile['layer']
         groups[key].append(tile)
 
     metatiles = []
     for group in groups.itervalues():
-        metatiles.extend(make_single_metatile(size, group, date_time))
+        parent = _parent_tile([t['coord'] for t in group])
+        metatiles.extend(make_multi_metatile(parent, group, date_time))
 
     return metatiles
 

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -13,6 +13,7 @@ import Queue
 import signal
 import sys
 import time
+import math
 
 
 # long enough to not fight with other threads, but not long enough
@@ -155,8 +156,9 @@ class DataFetch(object):
             # and its four children to cut from it. at zoom 15, this may
             # also include a whole bunch of other children below the max
             # zoom.
-            cut_coords = list(coord_children_range(
-                coord, coord.zoom + self.metatile_zoom))
+            cut_coords = list()
+            if nominal_zoom > coord.zoom:
+                cut_coords.extend(coord_children_range(coord, nominal_zoom))
             max_zoom = 16 - self.metatile_zoom
 
             assert coord.zoom <= max_zoom, \

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -129,7 +129,7 @@ class DataFetch(object):
                 break
 
             coord = data['coord']
-            nominal_zoom = coord.zoom
+            nominal_zoom = coord.zoom + self.metatile_zoom
             unpadded_bounds = coord_to_mercator_bounds(coord)
 
             start = time.time()
@@ -193,7 +193,6 @@ class DataFetch(object):
                 if async_exc_info:
                     continue
 
-            nominal_zoom = coord.zoom + self.metatile_zoom
             data = dict(
                 metadata=metadata,
                 coord=coord,


### PR DESCRIPTION
This adds support for 2x2 metatile and lays the foundation for 512px tiles. It does this by making the tilequeue worker operate on metatile-sized work chunks, where that is identified by a lower zoom tile coordinate.

The database is queried for the spatial extent of the metatile, but with the "zoom level" parameters set to the `nominal_zoom`, which is a measure of display scale, rather than the zoom of the tile coordinate. The post-processing is also run at the `nominal_zoom`.

Following that, smaller tiles are cut from the metatile, and all of them are put into the zip file which is uploaded to S3. No extra processing is done, so all the feature selection is performed at the `nominal_zoom` in the database or post-processor. Tiles are formatted separately, so should not incur serialisation overheads or coordinate precision loss.

At the moment, this only really supports `metatile.size=1` or `2`, as larger sizes such as `4` would also make tiles for the intermediate zoom. Making this fully configurable is left for another task.

Note that setting `metatile.size=2` in tileserver will probably also break it, since it expects to load and save single tiles at the moment. The next bit of work is to update both tileserver and tapalcatl to deal with different metatile sizes.