### PR TITLE
Emit additional metrics during intersection

### DIFF
--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -132,14 +132,18 @@ class TestUniquifyGenerator(unittest.TestCase):
             coord = sample_coord.zoomTo(i)
             coord_int = coord_marshall_int(coord)
             tiles_of_interest.append(coord_int)
-        exploded = explode_and_intersect([sample_coord_int], tiles_of_interest,
-                                         until=11)
+        exploded, metrics = explode_and_intersect(
+            [sample_coord_int], tiles_of_interest, until=11)
         coord_ints = list(exploded)
         for coord_int in coord_ints:
             coord = coord_unmarshall_int(coord_int)
             self.failUnless(coord.zoom > 10)
 
         self.assertEqual(4, len(coord_ints))
+
+        self.assertEqual(4, metrics['hits'])
+        self.assertEqual(0, metrics['misses'])
+        self.assertEqual(4, metrics['total'])
 
 
 class ZoomToQueueNameMapTest(unittest.TestCase):

--- a/tests/test_wof_http.py
+++ b/tests/test_wof_http.py
@@ -159,7 +159,7 @@ class TestWofHttp(unittest.TestCase):
             redis = _NullRedisTOI()
 
             def intersector(dummy1, dummy2, dummy3):
-                return []
+                return [], None
 
             def enqueuer(dummy):
                 pass

--- a/tilequeue/wof.py
+++ b/tilequeue/wof.py
@@ -1171,7 +1171,7 @@ class WofProcessor(object):
             self.logger.info('Intersecting %d tiles of interest with %d '
                              'expired tiles' % (
                                  len(toi), len(expired_coord_ints)))
-            toi_expired_coord_ints = self.intersector(
+            toi_expired_coord_ints, _ = self.intersector(
                 expired_coord_ints, toi, self.zoom_until)
             coords = map(coord_unmarshall_int, toi_expired_coord_ints)
             self.logger.info('Intersection complete, will expire %d tiles' %


### PR DESCRIPTION
Connects to https://github.com/mapzen/tile-tasks/issues/201
Refs https://github.com/mapzen/chef-mapzen_tilequeue/pull/29

This emits the stats to the log, and logstash will pick them up and send them over to statsd.

Longer term I think we should transition to the same approach we took in tapalcatl, namely to have the process itself send the stats directly.