### PR TITLE
Compress files in metatile.

### DIFF
--- a/tilequeue/metatile.py
+++ b/tilequeue/metatile.py
@@ -52,7 +52,7 @@ def make_multi_metatile(parent, tiles, date_time=None):
                 (delta_z, delta_column, delta_row, tile['format'].extension)
             tile_data = tile['tile']
             info = zipfile.ZipInfo(tile_name, date_time)
-            z.writestr(info, tile_data)
+            z.writestr(info, tile_data, zipfile.ZIP_DEFLATED)
 
     return [dict(tile=buf.getvalue(), format=zip_format, coord=parent,
                  layer=layer)]


### PR DESCRIPTION
On a random tile that I was testing with, this reduced file size by 79%.

The compressed metatile will take up less space in storage and transfer more quickly over the network. The disadvantage would be the CPU time required to decompress it. Looking at CPU usage on the tapalcatl machines, it's fairly light at the moment, so we've room to do more there.

What do you think? Should I make it configurable in case we need to turn it off in a hurry?