### PR TITLE
Fix some more bugs in metatile work

### DIFF
--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -177,7 +177,9 @@ class DataFetch(object):
                 async_fn = rci.is_coord_int_in_tiles_of_interest
 
                 for child in coord_children_range(coord, children_until):
-                    if child.zoom <= max_zoom:
+                    # tiles descended from coord up to nominal zoom are
+                    # already included - no need to include them again.
+                    if child.zoom <= nominal_zoom:
                         continue
                     zoomed_coord_int = coord_marshall_int(child)
                     async_result = self.io_pool.apply_async(

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -161,8 +161,12 @@ class DataFetch(object):
                 cut_coords.extend(coord_children_range(coord, nominal_zoom))
             max_zoom = 16 - self.metatile_zoom
 
-            assert coord.zoom <= max_zoom, \
-                "Job coordinates above max zoom are not supported"
+            if coord.zoom > max_zoom:
+                self.logger.log(
+                    logging.WARNING,
+                    'Job coordinates above max zoom are not supported, '
+                    'skipping %r > %d' % (coord, max_zoom))
+                continue
 
             if coord.zoom == max_zoom:
                 async_jobs = []


### PR DESCRIPTION
A couple of issues here:

1. Another `assert` was stopping the worker, this time when a coordinate was invalid. Perhaps we should put a general exception-catching block around the worker threads?
2. Some tiles which were in the TOI already and descended from the job coordinate were included in the tiles twice. This is only because the TOI contains 256px coordinates, rather than the 512px (i.e: `zoom - 1`, 2x2 metatile) coordinates, which shouldn't happen when we're fully switched over to 2x2 metatiles. But in the interim, seems like it would be better to be robust to these.

cc @rmarianski, @iandees. I'm merging this to unblock and continue, but would appreciate it if you could look it over and give me any advice you have for improving it, please.