### PR TITLE
Make queue sizes configurable.

### DIFF
--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -561,11 +561,11 @@ def tilequeue_process(cfg, peripherals):
     # geometry waiting to be processed from taking up all the RAM!
     default_queue_buffer_size = max(1, 128 >> (2 * cfg.metatile_size))
     sql_queue_buffer_size = cfg.sql_queue_buffer_size or \
-                            default_queue_buffer_size
+        default_queue_buffer_size
     proc_queue_buffer_size = cfg.proc_queue_buffer_size or \
-                             default_queue_buffer_size
+        default_queue_buffer_size
     s3_queue_buffer_size = cfg.s3_queue_buffer_size or \
-                           default_queue_buffer_size
+        default_queue_buffer_size
     n_layers = len(all_layer_data)
     n_formats = len(formats)
     n_simultaneous_s3_storage = cfg.n_simultaneous_s3_storage

--- a/tilequeue/config.py
+++ b/tilequeue/config.py
@@ -98,6 +98,10 @@ class Configuration(object):
         self.metatile_size = self._cfg('metatile size')
         self.store_orig = self._cfg('metatile store_metatile_and_originals')
 
+        self.sql_queue_buffer_size = self._cfg('queue_buffer_size sql')
+        self.proc_queue_buffer_size = self._cfg('queue_buffer_size proc')
+        self.s3_queue_buffer_size = self._cfg('queue_buffer_size s3')
+
     def _cfg(self, yamlkeys_str):
         yamlkeys = yamlkeys_str.split()
         yamlval = self.yml
@@ -188,6 +192,11 @@ def default_yml_config():
         'metatile': {
             'size': None,
             'store_metatile_and_originals': False,
+        },
+        'queue_buffer_size': {
+            'sql': None,
+            'proc': None,
+            's3': None,
         },
     }
 


### PR DESCRIPTION
And change the default to depend on metatile size. The amount of data waiting in the queue can be quite large. The previous default of 128 combined with 2x2 metatiling would occasionally exhaust all the memory available on a host.