### PR TITLE
Trap MemoryError, print a log message, and halt

### DIFF
--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -604,8 +604,8 @@ def tilequeue_process(cfg, peripherals):
     # create worker threads/processes
     thread_sqs_queue_reader_stop = threading.Event()
     sqs_queue_reader = SqsQueueReader(
-        sqs_queue, sqs_input_queue, logger, cfg.metatile_size,
-        thread_sqs_queue_reader_stop)
+        sqs_queue, sqs_input_queue, logger, thread_sqs_queue_reader_stop,
+        cfg.metatile_size)
 
     data_fetch = DataFetch(
         feature_fetcher, sqs_input_queue, sql_data_fetch_queue, io_pool,

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -65,7 +65,7 @@ class OutputQueue(object):
             stacktrace = format_stacktrace_one_line()
             self.logger.error(
                 "MemoryError while sending %s to the queue. Stacktrace: %s" %
-                (serialize_coord(msg.coord), stacktrace))
+                (serialize_coord(coord), stacktrace))
             # memory error might not leave the malloc subsystem in a usable
             # state, so better to exit the whole worker here than crash this
             # thread, which would lock up the whole worker.


### PR DESCRIPTION
MemoryError sometimes gets thrown when a very, very large message is put in a multiprocessing queue. This exception propagates up to the root of the thread and kills it, locking up the worker.

According to the Python docs, [MemoryError isn't entirely safe to recover from](https://docs.python.org/2/library/exceptions.html#exceptions.MemoryError), so instead this halts the whole process. It will be restarted by runit / systemd, and it might lose some work, but any lost jobs will be re-queued by SQS after a timeout.