### PR TITLE
Fix LinearRing error

### DIFF
--- a/tilequeue/transform.py
+++ b/tilequeue/transform.py
@@ -108,10 +108,17 @@ def _intersect_multipolygon(shape, tile_bounds, clip_bounds):
     polys = []
     for poly in shape.geoms:
         if tile_bounds.intersects(poly):
-            if clip_bounds.contains(poly):
+            if not clip_bounds.contains(poly):
+                poly = clip_bounds.intersection(poly)
+
+            if not poly.is_valid:
+                continue
+
+            if poly.type == 'Polygon':
                 polys.append(poly)
-            else:
-                polys.append(clip_bounds.intersection(poly))
+            elif poly.type == 'MultiPolygon':
+                polys.extend(poly.geoms)
+
     return geometry.MultiPolygon(polys)
 
 

--- a/tilequeue/transform.py
+++ b/tilequeue/transform.py
@@ -111,6 +111,10 @@ def _intersect_multipolygon(shape, tile_bounds, clip_bounds):
             if not clip_bounds.contains(poly):
                 poly = clip_bounds.intersection(poly)
 
+            # the intersection operation can make the resulting polygon
+            # invalid. including it in a MultiPolygon would make that
+            # invalid too. instead, we skip it, and hope it wasn't too
+            # important.
             if not poly.is_valid:
                 continue
 


### PR DESCRIPTION
Was seeing this error in the logs. It appears to be because a MultiPolygon is being interpreted as a Polygon, and therefore has the wrong number of outer rings. To fix this, we just decompose the MultiPolygon into its constituent Polygons.