### PR TITLE
Command to automatically prune tiles of interest

### DIFF
--- a/logging.conf.sample
+++ b/logging.conf.sample
@@ -1,5 +1,5 @@
 [loggers]
-keys=root,process,seed,intersect,drain,enqueue_tiles_of_interest,dump_tiles_of_interest,wof_process_neighbourhoods,query
+keys=root,process,seed,intersect,drain,prune_tiles_of_interest,enqueue_tiles_of_interest,dump_tiles_of_interest,wof_process_neighbourhoods,query
 
 [handlers]
 keys=consoleHandler
@@ -10,6 +10,12 @@ keys=simpleFormatter
 [logger_root]
 level=WARNING
 handlers=consoleHandler
+
+[logger_prune_tiles_of_interest]
+level=INFO
+handlers=consoleHandler
+qualName=prune_tiles_of_interest
+propagate=0
 
 [logger_enqueue_tiles_of_interest]
 level=INFO

--- a/tilequeue/cache/redis_cache_index.py
+++ b/tilequeue/cache/redis_cache_index.py
@@ -18,7 +18,7 @@ class RedisCacheIndex(object):
                 yield coord
 
     def remove_tiles_of_interest(self, coord_ints):
-        self.redis_client.srem(self.cache_set_key, coord_ints)
+        return self.redis_client.srem(self.cache_set_key, coord_ints)
 
     def fetch_tiles_of_interest(self):
         raw_tiles_of_interest = self.redis_client.smembers(self.cache_set_key)

--- a/tilequeue/cache/redis_cache_index.py
+++ b/tilequeue/cache/redis_cache_index.py
@@ -17,6 +17,9 @@ class RedisCacheIndex(object):
             if serialized_coord in tiles_of_interest:
                 yield coord
 
+    def remove_tiles_of_interest(self, coord_ints):
+        self.redis_client.srem(self.cache_set_key, coord_ints)
+
     def fetch_tiles_of_interest(self):
         raw_tiles_of_interest = self.redis_client.smembers(self.cache_set_key)
         tiles_of_interest = set()

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -29,7 +29,7 @@ from tilequeue.tile import tile_generator_for_multiple_bounds
 from tilequeue.tile import tile_generator_for_single_bounds
 from tilequeue.tile import zoom_mask
 from tilequeue.top_tiles import parse_top_tiles
-from tilequeue.util import chunker
+from tilequeue.utils import chunker
 from tilequeue.worker import DataFetch
 from tilequeue.worker import ProcessAndFormatData
 from tilequeue.worker import QueuePrint

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -29,7 +29,7 @@ from tilequeue.tile import tile_generator_for_multiple_bounds
 from tilequeue.tile import tile_generator_for_single_bounds
 from tilequeue.tile import zoom_mask
 from tilequeue.top_tiles import parse_top_tiles
-from tilequeue.utils import chunker
+from tilequeue.utils import grouper
 from tilequeue.worker import DataFetch
 from tilequeue.worker import ProcessAndFormatData
 from tilequeue.worker import QueuePrint
@@ -1046,7 +1046,7 @@ def tilequeue_prune_tiles_of_interest(cfg, peripherals):
         buk.delete_keys(keys)
 
     path_parts = prune_cfg.get('s3')
-    for coord_ints in chunker(toi_to_remove, 1000):
+    for coord_ints in grouper(toi_to_remove, 1000):
         # FIXME: Think about doing this in a thread/process pool
         delete_tile_of_interest(path_parts, coord_ints)
 

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -1053,7 +1053,6 @@ def tilequeue_prune_tiles_of_interest(cfg, peripherals):
         logger.info('Removed %s tiles from S3', removed)
 
     for coord_ints in grouper(toi_to_remove, 1000):
-        # FIXME: Think about doing this in a thread/process pool
         delete_tile_of_interest(s3_parts, coord_ints)
 
     logger.info('Removing %s tiles from TOI and S3 ... done',

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -995,9 +995,10 @@ def tilequeue_prune_tiles_of_interest(cfg, peripherals):
 
     def delete_tile_of_interest(coord_int):
         # Remove from the redis toi set
+        # FIXME: This doesn't exist yet
         peripherals.redis_cache_index.remove_tile_of_interest(coord_int)
 
-        # Remove the tile from S3
+        # FIXME: Remove the tile from S3
 
         pass
 

--- a/tilequeue/tile.py
+++ b/tilequeue/tile.py
@@ -34,7 +34,7 @@ def deserialize_coord(coord_string):
 
 
 def create_coord(x, y, z):
-    return Coordinate(row=x, column=y, zoom=z)
+    return Coordinate(row=y, column=x, zoom=z)
 
 
 def parse_expired_coord_string(coord_string):

--- a/tilequeue/tile.py
+++ b/tilequeue/tile.py
@@ -33,6 +33,10 @@ def deserialize_coord(coord_string):
     return coord
 
 
+def create_coord(x, y, z):
+    return Coordinate(row=x, column=y, zoom=z)
+
+
 def parse_expired_coord_string(coord_string):
     # we use the same format in the queue as the expired tile list from
     # osm2pgsql

--- a/tilequeue/utils.py
+++ b/tilequeue/utils.py
@@ -14,5 +14,5 @@ def format_stacktrace_one_line(exc_info=None):
     return stacktrace
 
 
-def chunker(seq, size):
+def grouper(seq, size):
     return (seq[pos:pos + size] for pos in xrange(0, len(seq), size))

--- a/tilequeue/utils.py
+++ b/tilequeue/utils.py
@@ -1,5 +1,6 @@
 import sys
 import traceback
+from itertools import izip_longest
 
 
 def format_stacktrace_one_line(exc_info=None):
@@ -14,6 +15,7 @@ def format_stacktrace_one_line(exc_info=None):
     return stacktrace
 
 
-def grouper(seq, size):
+def grouper(iterable, n, fillvalue=None):
     """Collect data into fixed-length chunks or blocks"""
-    return (seq[pos:pos + size] for pos in xrange(0, len(seq), size))
+    args = [iter(iterable)] * n
+    return izip_longest(fillvalue=fillvalue, *args)

--- a/tilequeue/utils.py
+++ b/tilequeue/utils.py
@@ -12,3 +12,7 @@ def format_stacktrace_one_line(exc_info=None):
     stacktrace = ' | '.join([x.replace('\n', '')
                              for x in exception_lines])
     return stacktrace
+
+
+def chunker(seq, size):
+    return (seq[pos:pos + size] for pos in xrange(0, len(seq), size))


### PR DESCRIPTION
Adding a command that prunes the tiles of interest by checking for tiles that were frequently requested and removing tiles from the tiles of interest set (and from S3) that **were not** frequently requested.