### PR TITLE
Account for tilesize on RedShift records

### DIFF
--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -981,7 +981,7 @@ def tilequeue_prune_tiles_of_interest(cfg, peripherals):
                 select x, y, z, tilesize
                 from tile_traffic_v4
                 where (date >= dateadd(day, -{days}, current_date))
-                  and (z between 10 and 16)
+                  and (z between 0 and 15)
                   and (x between 0 and pow(2,z)-1)
                   and (y between 0 and pow(2,z)-1)
                 group by z, x, y

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -978,7 +978,7 @@ def tilequeue_prune_tiles_of_interest(cfg, peripherals):
     with psycopg2.connect(redshift_uri) as conn:
         with conn.cursor() as cur:
             cur.execute("""
-                select x, y, z
+                select x, y, z, tilesize
                 from tile_traffic_v4
                 where (date >= dateadd(day, -{days}, current_date))
                   and (z between 10 and 16)
@@ -987,9 +987,14 @@ def tilequeue_prune_tiles_of_interest(cfg, peripherals):
                 group by z, x, y
                 order by z, x, y;""".format(days=redshift_days_to_query))
             n_trr = cur.rowcount
-            for (x, y, z) in cur:
+            for (x, y, z, tile_size) in cur:
                 coord = create_coord(x, y, z)
                 coord_int = coord_marshall_int(coord)
+
+                if not tile_size or tile_size == '256':
+                    # "uplift" a tile that is not explicitly a '512' size tile
+                    coord_int = coord_int_zoom_up(coord_int)
+
                 new_toi.add(coord_int)
 
     logger.info('Fetching tiles recently requested ... done. %s found', n_trr)


### PR DESCRIPTION
Follow of #178, #176.

Standardize on 512px-sized tiles in the tiles of interest by "zooming out" the records from RedShift if they don't specify 512px as the requested tile size.