### PR TITLE
Add to tiles of interest as part of tilequeue "pruner" command

### DIFF
--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -1077,20 +1077,19 @@ def tilequeue_prune_tiles_of_interest(cfg, peripherals):
     logger.info('Computing tiles to add ... done. %s found',
                 len(toi_to_add))
 
-    logger.info('Adding %s tiles to TOI and SQS ...',
+    logger.info('Enqueueing %s tiles to SQS ...',
                 len(toi_to_add))
 
-    def add_tile_of_interest(coord_int):
-        # Add to Redis
+    sqs_queue = peripherals.queue
+    enqueuer = ThreadedEnqueuer(sqs_queue, cfg.seed_n_threads, logger)
+    n_queued, n_in_flight = enqueuer(
+        coord_unmarshall_int(coord_int) for coord_int in toi_to_add
+    )
 
-        # Enqueue a render request for the tile
-        pass
-
-    for coord_int in toi_to_add:
-        add_tile_of_interest(coord_int)
-
-    logger.info('Adding %s tiles to TOI and SQS ... done',
+    logger.info('Enqueueing %s tiles to SQS ... done',
                 len(toi_to_add))
+
+    logger.info('Pruning tiles of interest ... done')
 
 
 def tilequeue_tile_sizes(cfg, peripherals):

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -1077,6 +1077,15 @@ def tilequeue_prune_tiles_of_interest(cfg, peripherals):
     logger.info('Computing tiles to add ... done. %s found',
                 len(toi_to_add))
 
+    logger.info('Adding %s tiles to Redis TOI set ...',
+                len(toi_to_add))
+
+    for coord_ints in grouper(toi_to_add, 1000):
+        peripherals.redis_cache_index.remove_tiles_of_interest(coord_ints)
+
+    logger.info('Adding %s tiles to Redis TOI set ... done',
+                len(toi_to_add))
+
     logger.info('Enqueueing %s tiles to SQS ...',
                 len(toi_to_add))
 

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -1038,9 +1038,6 @@ def tilequeue_prune_tiles_of_interest(cfg, peripherals):
     logger.info('Computing tiles to remove ... done. %s found',
                 len(toi_to_remove))
 
-    # Null out the reference to old TOI to save some memory
-    tiles_of_interest = None
-
     logger.info('Removing %s tiles from TOI and S3 ...',
                 len(toi_to_remove))
 
@@ -1074,6 +1071,26 @@ def tilequeue_prune_tiles_of_interest(cfg, peripherals):
 
     logger.info('Removing %s tiles from TOI and S3 ... done',
                 len(toi_to_remove))
+
+    logger.info('Computing tiles to add ...')
+    toi_to_add = new_toi - tiles_of_interest
+    logger.info('Computing tiles to add ... done. %s found',
+                len(toi_to_add))
+
+    logger.info('Adding %s tiles to TOI and SQS ...',
+                len(toi_to_add))
+
+    def add_tile_of_interest(coord_int):
+        # Add to Redis
+
+        # Enqueue a render request for the tile
+        pass
+
+    for coord_int in toi_to_add:
+        add_tile_of_interest(coord_int)
+
+    logger.info('Adding %s tiles to TOI and SQS ... done',
+                len(toi_to_add))
 
 
 def tilequeue_tile_sizes(cfg, peripherals):


### PR DESCRIPTION
This adds the ability to include new tiles in the tiles of interest as part of the "prune" tilequeue command that was added in #176. This is a counterpart to https://github.com/tilezen/tileserver/pull/85, which pulls out the enqueueing and TOI adding piece from tileserver.