### PR TITLE
Move the zoom to enqueue to 15

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -84,8 +84,8 @@ tiles:
     # process on update
     parent-zoom-until: 11
 
-  # this is the max zoom used when enqueueing the tiles of interest
-  enqueue_max_zoom: 15
+  # zoom where tile content stops changing
+  max-zoom-with-changes: 16
 
 process:
   # number of simultaneous "querysets" to issue to the database.  The

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -84,6 +84,9 @@ tiles:
     # process on update
     parent-zoom-until: 11
 
+  # this is the max zoom used when enqueueing the tiles of interest
+  enqueue_max_zoom: 15
+
 process:
   # number of simultaneous "querysets" to issue to the database.  The
   # query for each layer will be issued in parallel to the same

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -611,11 +611,11 @@ def tilequeue_process(cfg, peripherals):
     thread_sqs_queue_reader_stop = threading.Event()
     sqs_queue_reader = SqsQueueReader(
         sqs_queue, sqs_input_queue, logger, thread_sqs_queue_reader_stop,
-        cfg.metatile_size)
+        cfg.max_zoom)
 
     data_fetch = DataFetch(
         feature_fetcher, sqs_input_queue, sql_data_fetch_queue, io_pool,
-        peripherals.redis_cache_index, logger, cfg.metatile_size)
+        peripherals.redis_cache_index, logger, cfg.metatile_zoom, cfg.max_zoom)
 
     data_processor = ProcessAndFormatData(
         post_process_data, formats, sql_data_fetch_queue, processor_queue,
@@ -1551,7 +1551,8 @@ def tilequeue_main(argv_args=None):
     args = parser.parse_args(argv_args)
     assert os.path.exists(args.config), \
         'Config file {} does not exist!'.format(args.config)
-    cfg = make_config_from_argparse(args.config)
+    with open(args.config) as fh:
+        cfg = make_config_from_argparse(fh)
     redis_client = make_redis_client(cfg)
     Peripherals = namedtuple('Peripherals', 'redis_cache_index queue stats')
     queue = make_queue(

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -944,7 +944,7 @@ def tilequeue_enqueue_tiles_of_interest(cfg, peripherals):
     coords = []
     for coord_int in tiles_of_interest:
         coord = coord_unmarshall_int(coord_int)
-        if coord.zoom <= 15:
+        if coord.zoom <= cfg.enqueue_max_zoom:
             coords.append(coord)
 
     enqueuer = ThreadedEnqueuer(sqs_queue, cfg.seed_n_threads, logger)

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -944,7 +944,7 @@ def tilequeue_enqueue_tiles_of_interest(cfg, peripherals):
     coords = []
     for coord_int in tiles_of_interest:
         coord = coord_unmarshall_int(coord_int)
-        if coord.zoom <= 16:
+        if coord.zoom <= 15:
             coords.append(coord)
 
     enqueuer = ThreadedEnqueuer(sqs_queue, cfg.seed_n_threads, logger)

--- a/tilequeue/config.py
+++ b/tilequeue/config.py
@@ -24,6 +24,8 @@ class Configuration(object):
         self.s3_path = self._cfg('store path')
         self.s3_date_prefix = self._cfg('store date-prefix')
 
+        self.enqueue_max_zoom = self.yml['tiles']['enqueue_max_zoom']
+
         seed_cfg = self.yml['tiles']['seed']
         self.seed_all_zoom_start = seed_cfg['all']['zoom-start']
         self.seed_all_zoom_until = seed_cfg['all']['zoom-until']
@@ -166,6 +168,7 @@ def default_yml_config():
                 'expired-location': None,
                 'parent-zoom-until': None,
             },
+            'enqueue_max_zoom': 15,
         },
         'process': {
             'n-simultaneous-query-sets': 0,

--- a/tilequeue/config.py
+++ b/tilequeue/config.py
@@ -1,5 +1,6 @@
 from tilequeue.tile import bounds_buffer
 from yaml import load
+import math
 
 
 class Configuration(object):
@@ -23,8 +24,6 @@ class Configuration(object):
         self.s3_reduced_redundancy = self._cfg('store reduced-redundancy')
         self.s3_path = self._cfg('store path')
         self.s3_date_prefix = self._cfg('store date-prefix')
-
-        self.enqueue_max_zoom = self.yml['tiles']['enqueue_max_zoom']
 
         seed_cfg = self.yml['tiles']['seed']
         self.seed_all_zoom_start = seed_cfg['all']['zoom-start']
@@ -104,6 +103,17 @@ class Configuration(object):
         self.wof = self.yml.get('wof')
 
         self.metatile_size = self._cfg('metatile size')
+        if self.metatile_size is None:
+            self.metatile_zoom = 0
+        else:
+            self.metatile_zoom = int(math.log(self.metatile_size, 2))
+            assert (1 << self.metatile_zoom) == self.metatile_size, \
+                "Metatile size must be a power of two."
+
+        self.max_zoom_with_changes = self._cfg('tiles max-zoom-with-changes')
+        assert self.max_zoom_with_changes > self.metatile_zoom
+        self.max_zoom = self.max_zoom_with_changes - self.metatile_zoom
+
         self.store_orig = self._cfg('metatile store_metatile_and_originals')
 
         self.sql_queue_buffer_size = self._cfg('queue_buffer_size sql')
@@ -168,7 +178,7 @@ def default_yml_config():
                 'expired-location': None,
                 'parent-zoom-until': None,
             },
-            'enqueue_max_zoom': 15,
+            'max-zoom-with-changes': 16,
         },
         'process': {
             'n-simultaneous-query-sets': 0,
@@ -220,12 +230,11 @@ def merge_cfg(dest, source):
     return dest
 
 
-def make_config_from_argparse(config_path, opencfg=open):
-    # opencfg for testing
-    cfg = default_yml_config()
-    with opencfg(config_path) as config_fp:
-        yml_data = load(config_fp.read())
-        cfg = merge_cfg(cfg, yml_data)
+def make_config_from_argparse(config_file_handle, default_yml=None):
+    if default_yml is None:
+        default_yml = default_yml_config()
+    yml_data = load(config_file_handle)
+    cfg = merge_cfg(default_yml, yml_data)
     return Configuration(cfg)
 
 


### PR DESCRIPTION
This gets run when enqueueing the tiles of interest, when we deploy to prod and enqueue all the tiles. This should be set to z15 now.

This wasn't changing really changing before, but maybe this should be set from configuration now? Or perhaps we do it next time if/when this changes?