### PR TITLE
A couple cleanups from running the gardener locally

### DIFF
--- a/tilequeue/cache/redis_cache_index.py
+++ b/tilequeue/cache/redis_cache_index.py
@@ -18,6 +18,8 @@ class RedisCacheIndex(object):
                 yield coord
 
     def remove_tiles_of_interest(self, coord_ints):
+        # Note that this will end up as a single SREM call to Redis,
+        # so you should probably group the coords into ~1000s.
         return self.redis_client.srem(self.cache_set_key, *coord_ints)
 
     def fetch_tiles_of_interest(self):

--- a/tilequeue/cache/redis_cache_index.py
+++ b/tilequeue/cache/redis_cache_index.py
@@ -18,7 +18,7 @@ class RedisCacheIndex(object):
                 yield coord
 
     def remove_tiles_of_interest(self, coord_ints):
-        return self.redis_client.srem(self.cache_set_key, coord_ints)
+        return self.redis_client.srem(self.cache_set_key, *coord_ints)
 
     def fetch_tiles_of_interest(self):
         raw_tiles_of_interest = self.redis_client.smembers(self.cache_set_key)

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -984,8 +984,9 @@ def tilequeue_prune_tiles_of_interest(cfg, peripherals):
                   and (z between 0 and 15)
                   and (x between 0 and pow(2,z)-1)
                   and (y between 0 and pow(2,z)-1)
-                group by z, x, y
-                order by z, x, y;""".format(days=redshift_days_to_query))
+                group by z, x, y, tilesize
+                order by z, x, y, tilesize
+                """.format(days=redshift_days_to_query))
             n_trr = cur.rowcount
             for (x, y, z, tile_size) in cur:
                 coord = create_coord(x, y, z)
@@ -1019,6 +1020,9 @@ def tilequeue_prune_tiles_of_interest(cfg, peripherals):
                     coord_marshall_int(deserialize_coord(l.strip()))
                     for l in f
                 )
+
+        # Filter out nulls that might sneak in for various reasons
+        immortal_tiles = filter(None, immortal_tiles)
 
         n_inc = len(immortal_tiles)
         new_toi = new_toi.union(immortal_tiles)


### PR DESCRIPTION
A couple cleanups from #180.

- Have to include tilesize in the redshift group by query
- Filter out null tile coords that might sneak in to the immortal tiles section
- The redis client expects srem args to be a star-arg, not a list