### PR TITLE
Add configurable request and tile count cutoffs

### DIFF
--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -1,5 +1,6 @@
 from collections import Iterable
 from collections import namedtuple
+from collections import defaultdict
 from contextlib import closing
 from itertools import chain
 from jinja2 import Environment
@@ -977,7 +978,7 @@ def tilequeue_prune_tiles_of_interest(cfg, peripherals):
     assert s3_parts, ("The name of an S3 bucket containing tiles "
                       "to delete must be specified")
 
-    redshift_results = dict()
+    redshift_results = defaultdict(int)
     with psycopg2.connect(redshift_uri) as conn:
         with conn.cursor() as cur:
             cur.execute("""
@@ -1003,13 +1004,7 @@ def tilequeue_prune_tiles_of_interest(cfg, peripherals):
 
                 # Sum the counts from the 256 and 512 tile requests into the
                 # slot for the 512 tile.
-                existing_count = redshift_results.get(coord_int)
-                if existing_count:
-                    existing_count += count
-                else:
-                    existing_count = count
-
-                redshift_results[coord_int] = existing_count
+                redshift_results[coord_int] += count
 
     logger.info('Fetching tiles recently requested ... done. %s found',
                 len(redshift_results))

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -1022,7 +1022,7 @@ def tilequeue_prune_tiles_of_interest(cfg, peripherals):
     new_toi = set()
     for coord_int, count in sorted(
             redshift_results.iteritems(),
-            operator.itemgetter(1),
+            key=operator.itemgetter(1),
             reverse=True)[:cutoff_tiles]:
         if count >= cutoff_requests:
             new_toi.add(coord_int)

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -44,6 +44,7 @@ import argparse
 import logging
 import logging.config
 import multiprocessing
+import operator
 import os
 import Queue
 import signal
@@ -1018,16 +1019,14 @@ def tilequeue_prune_tiles_of_interest(cfg, peripherals):
                 cutoff_requests,
                 )
 
-    # Sort redshift_results (a dict of coord_int->score) by the score value,
-    # filter out the coords that didn't meet the requests cutoff,
-    # then take the first `cutoff_tiles`.
+    new_toi = set()
+    for coord_int, count in sorted(
+            redshift_results.iteritems(),
+            operator.itemgetter(1),
+            reverse=True)[:cutoff_tiles]:
+        if count >= cutoff_requests:
+            new_toi.add(coord_int)
 
-    new_toi = set(
-        t[0] for t in filter(
-            lambda t: t[1] >= cutoff_requests,
-            sorted(redshift_results.iteritems(), key=lambda t: t[1])
-        )[:cutoff_tiles]
-    )
     redshift_results = None
 
     logger.info('Finding %s tiles requested %s+ times ... done. Found %s',

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -208,7 +208,6 @@ class DataFetch(object):
 
             metadata = data['metadata']
             metadata['timing']['fetch_seconds'] = time.time() - start
-            max_zoom = 16 - self.metatile_zoom
 
             # every tile job that we get from the queue is a "parent" tile
             # and its four children to cut from it. at zoom 15, this may
@@ -217,39 +216,6 @@ class DataFetch(object):
             cut_coords = list()
             if nominal_zoom > coord.zoom:
                 cut_coords.extend(coord_children_range(coord, nominal_zoom))
-
-            if coord.zoom == max_zoom:
-                async_jobs = []
-                children_until = 20
-                # ask redis if there are any tiles underneath in the
-                # tiles of interest set
-                rci = self.redis_cache_index
-                async_fn = rci.is_coord_int_in_tiles_of_interest
-
-                for child in coord_children_range(coord, children_until):
-                    # tiles descended from coord up to nominal zoom are
-                    # already included - no need to include them again.
-                    if child.zoom <= nominal_zoom:
-                        continue
-                    zoomed_coord_int = coord_marshall_int(child)
-                    async_result = self.io_pool.apply_async(
-                        async_fn, (zoomed_coord_int,))
-                    async_jobs.append((child, async_result))
-
-                async_exc_info = None
-                for async_job in async_jobs:
-                    zoomed_coord, async_result = async_job
-                    try:
-                        is_coord_in_tiles_of_interest = async_result.get()
-                    except:
-                        async_exc_info = sys.exc_info()
-                        stacktrace = format_stacktrace_one_line(async_exc_info)
-                        self.logger.error(stacktrace)
-                    else:
-                        if is_coord_in_tiles_of_interest:
-                            cut_coords.append(zoomed_coord)
-                if async_exc_info:
-                    continue
 
             data = dict(
                 metadata=metadata,

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -3,7 +3,6 @@ from psycopg2.extensions import TransactionRollbackError
 from tilequeue.process import process_coord
 from tilequeue.store import write_tile_if_changed
 from tilequeue.tile import coord_children_range
-from tilequeue.tile import coord_marshall_int
 from tilequeue.tile import coord_to_mercator_bounds
 from tilequeue.tile import serialize_coord
 from tilequeue.utils import format_stacktrace_one_line


### PR DESCRIPTION
This allows us to specify a maximum number of tiles to include from RedShift in the tiles of interest (the "immortal tiles" will always be included). It also adds a tile request count cutoff. These two cutoff values should let us more carefully specify how much work we want tilequeue to do.