### PR TITLE
Replace 'enqueue_max_zoom' with 'max_zoom'

### DIFF
--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -944,7 +944,7 @@ def tilequeue_enqueue_tiles_of_interest(cfg, peripherals):
     coords = []
     for coord_int in tiles_of_interest:
         coord = coord_unmarshall_int(coord_int)
-        if coord.zoom <= cfg.enqueue_max_zoom:
+        if coord.zoom <= cfg.max_zoom:
             coords.append(coord)
 
     enqueuer = ThreadedEnqueuer(sqs_queue, cfg.seed_n_threads, logger)


### PR DESCRIPTION
Got this while trying to seed the TOI:

```
Traceback (most recent call last):
  File "/usr/local/bin/tilequeue", line 11, in <module>
    load_entry_point('tilequeue==1.6.0', 'console_scripts', 'tilequeue')()
  File "/usr/local/lib/python2.7/dist-packages/tilequeue/command.py", line 1589, in tilequeue_main
    args.func(cfg, peripherals)
  File "/usr/local/lib/python2.7/dist-packages/tilequeue/command.py", line 947, in tilequeue_enqueue_tiles_of_interest
    if coord.zoom <= cfg.enqueue_max_zoom:
AttributeError: 'Configuration' object has no attribute 'enqueue_max_zoom'
```

Should that be just `max_zoom` now?