### PR TITLE
Remove Redis TOI dump command

### DIFF
--- a/logging.conf.sample
+++ b/logging.conf.sample
@@ -1,5 +1,5 @@
 [loggers]
-keys=root,process,seed,intersect,drain,prune_tiles_of_interest,enqueue_tiles_of_interest,dump_tiles_of_interest,dump_tiles_of_interest_from_redis,load_tiles_of_interest,wof_process_neighbourhoods,query
+keys=root,process,seed,intersect,drain,prune_tiles_of_interest,enqueue_tiles_of_interest,dump_tiles_of_interest,load_tiles_of_interest,wof_process_neighbourhoods,query
 
 [handlers]
 keys=consoleHandler
@@ -27,12 +27,6 @@ propagate=0
 level=INFO
 handlers=consoleHandler
 qualName=dump_tiles_of_interest
-propagate=0
-
-[logger_dump_tiles_of_interest_from_redis]
-level=INFO
-handlers=consoleHandler
-qualName=dump_tiles_of_interest_from_redis
 propagate=0
 
 [logger_load_tiles_of_interest]

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -1410,45 +1410,6 @@ def tilequeue_dump_tiles_of_interest(cfg, peripherals):
     )
 
 
-def tilequeue_dump_tiles_of_interest_from_redis(cfg, peripherals):
-    """
-    Dumps the tiles of interest from Redis into a newline-delimited
-    file called 'toi.txt'.
-
-    This is intended to be used once to migrate away from using Redis
-    and then removed.
-    """
-    logger = make_logger(cfg, 'dump_tiles_of_interest_from_redis')
-    logger.info('Dumping TOI from Redis ...')
-
-    logger.info('Fetching tiles of interest from Redis ...')
-
-    # Make a raw Redis client so we can do low-level set manipulation
-    redis_client = make_redis_client(cfg)
-
-    toi_iter = redis_client.sscan_iter(cfg.redis_cache_set_key, count=10000)
-
-    toi_set = set()
-    for coord_int in toi_iter:
-        toi_set.add(coord_int)
-
-    logger.info('Fetching tiles of interest from Redis ... done')
-
-    toi_filename = "toi.txt"
-
-    n_toi = len(toi_set)
-    logger.info('Writing %d tiles of interest to %s ...', n_toi, toi_filename)
-
-    with open(toi_filename, "w") as f:
-        save_set_to_fp(toi_set, f)
-
-    logger.info(
-        'Writing %d tiles of interest to %s ... done',
-        n_toi,
-        toi_filename
-    )
-
-
 def tilequeue_load_tiles_of_interest(cfg, peripherals):
     """
     Given a newline-delimited file containing tile coordinates in
@@ -1527,9 +1488,6 @@ def tilequeue_main(argv_args=None):
         ('intersect', create_command_parser(tilequeue_intersect)),
         ('dump-tiles-of-interest',
             create_command_parser(tilequeue_dump_tiles_of_interest)),
-        ('dump-tiles-of-interest-from-redis',
-            create_command_parser(
-                tilequeue_dump_tiles_of_interest_from_redis)),
         ('load-tiles-of-interest',
             create_command_parser(tilequeue_load_tiles_of_interest)),
         ('enqueue-tiles-of-interest',


### PR DESCRIPTION
After we migrate the tiles of interest set from Redis in #193, we should merge this PR so that the command that dumps from Redis is removed.