### PR TITLE
create a TOI set on seed if toi-set file doesn’t exist

### DIFF
--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -910,7 +910,10 @@ def tilequeue_seed(cfg, peripherals):
     if cfg.seed_should_add_to_tiles_of_interest:
         logger.info('Adding to Tiles of Interest ... ')
 
-        toi_set = peripherals.toi.fetch_tiles_of_interest()
+        if not os.path.exists(cfg.toi_store_file_name) and cfg.toi_store_type == 'file':
+            toi_set = set()
+        else:
+            toi_set = peripherals.toi.fetch_tiles_of_interest()
 
         tile_generator = make_seed_tile_generator(cfg)
         for coord in tile_generator:


### PR DESCRIPTION
`Tilequeue seed` fails if **should-add-to-tiles-of-interest** is set and TOI-set file doesn't exist.

Instead of creating toi.txt and then calling `tilequeue load-tiles-of-interest`, `tilequeue seed` should be able to proceed with empty TOI if none was created.