### PR TITLE
Remove the s3 config namespace

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -228,6 +228,5 @@ toi-prune:
     #  file: list-of-tile-coordinates.txt
     # NOTE: the coordinates should be of the same size as the toi, currently 512
     # integration-test-coordinates:
-    #   s3:
-    #     bucket: mapzen-tiles-assets
-    #     key: test/integration-test-coords.txt
+    #   bucket: mapzen-tiles-assets
+    #   key: test/integration-test-coords.txt

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -1078,8 +1078,8 @@ def tilequeue_prune_tiles_of_interest(cfg, peripherals):
             from boto import connect_s3
             from boto.s3.bucket import Bucket
             s3_conn = connect_s3()
-            bucket = Bucket(s3_conn, info['s3']['bucket'])
-            key = bucket.get_key(info['s3']['key'])
+            bucket = Bucket(s3_conn, info['bucket'])
+            key = bucket.get_key(info['key'])
             raw_coord_data = key.get_contents_as_string()
             for line in raw_coord_data.splitlines():
                 coord = deserialize_coord(line.strip())


### PR DESCRIPTION
Removing the namespace makes the configuration similar to the others, which means we don't need to make any changes on the chef side to generate the config.