### PR TITLE
Update info guard

### DIFF
--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -1074,7 +1074,7 @@ def tilequeue_prune_tiles_of_interest(cfg, peripherals):
                     coord_marshall_int(deserialize_coord(l.strip()))
                     for l in f
                 )
-        elif 's3' in info:
+        elif 'bucket' in info:
             from boto import connect_s3
             from boto.s3.bucket import Bucket
             s3_conn = connect_s3()


### PR DESCRIPTION
The s3 namespace was removed from the config, and the guard needs to get
updated to trigger the logic to add in the integration test tiles into
the immortal set.