### PR TITLE
Remove store_metatile_and_originals config

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -169,11 +169,6 @@ metatile:
   # be available in the future.
   size: null
 
-  # if this is set to true, then tilequeue will write the individual formats in
-  # addition to the metatile. this can be useful when gracefully "cutting over"
-  # to a metatile-based system from an individual format based one.
-  store_metatile_and_originals: false
-
 # Configuration for where to store the tiles of interest set
 toi-store:
   # We support storing the TOI in S3 or as a file

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -626,8 +626,8 @@ def tilequeue_process(cfg, peripherals):
         post_process_data, formats, sql_data_fetch_queue, processor_queue,
         cfg.buffer_cfg, logger)
 
-    s3_storage = S3Storage(processor_queue, s3_store_queue, io_pool,
-                           store, logger, cfg.metatile_size, cfg.store_orig)
+    s3_storage = S3Storage(processor_queue, s3_store_queue, io_pool, store,
+                           logger, cfg.metatile_size)
 
     thread_sqs_writer_stop = threading.Event()
     sqs_queue_writer = SqsQueueWriter(sqs_queue, s3_store_queue, logger,

--- a/tilequeue/config.py
+++ b/tilequeue/config.py
@@ -122,8 +122,6 @@ class Configuration(object):
         assert self.max_zoom_with_changes > self.metatile_zoom
         self.max_zoom = self.max_zoom_with_changes - self.metatile_zoom
 
-        self.store_orig = self._cfg('metatile store_metatile_and_originals')
-
         self.sql_queue_buffer_size = self._cfg('queue_buffer_size sql')
         self.proc_queue_buffer_size = self._cfg('queue_buffer_size proc')
         self.s3_queue_buffer_size = self._cfg('queue_buffer_size s3')
@@ -221,7 +219,6 @@ def default_yml_config():
         },
         'metatile': {
             'size': None,
-            'store_metatile_and_originals': False,
         },
         'queue_buffer_size': {
             'sql': None,

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -298,14 +298,13 @@ class ProcessAndFormatData(object):
 class S3Storage(object):
 
     def __init__(self, input_queue, output_queue, io_pool, store, logger,
-                 metatile_size, store_metatile_and_originals=False):
+                 metatile_size):
         self.input_queue = input_queue
         self.output_queue = output_queue
         self.io_pool = io_pool
         self.store = store
         self.logger = logger
         self.metatile_size = metatile_size
-        self.store_metatile_and_originals = store_metatile_and_originals
 
     def __call__(self, stop):
         saw_sentinel = False
@@ -381,14 +380,7 @@ class S3Storage(object):
         async_jobs = []
 
         if self.metatile_size:
-            metatiles = make_metatiles(self.metatile_size, tiles)
-
-            # allow the metatile to be stored, or both the metatile
-            # and originals, which allows for a smooth cutover.
-            if self.store_metatile_and_originals:
-                tiles.extend(metatiles)
-            else:
-                tiles = metatiles
+            tiles = make_metatiles(self.metatile_size, tiles)
 
         for tile in tiles:
 


### PR DESCRIPTION
The store_metatile_and_originals config is no longer used. It was removed from tileserver as part of https://github.com/tilezen/tileserver/pull/94