### PR TITLE
Retry deleting tiles on S3.

### DIFF
--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -433,7 +433,8 @@ def make_store(store_type, store_name, cfg):
         return make_s3_store(
             cfg.s3_bucket, cfg.aws_access_key_id, cfg.aws_secret_access_key,
             path=cfg.s3_path, reduced_redundancy=cfg.s3_reduced_redundancy,
-            date_prefix=cfg.s3_date_prefix)
+            date_prefix=cfg.s3_date_prefix,
+            delete_retry_interval=cfg.s3_delete_retry_interval)
 
     else:
         raise ValueError('Unrecognized store type: `{}`'.format(store_type))

--- a/tilequeue/config.py
+++ b/tilequeue/config.py
@@ -24,6 +24,8 @@ class Configuration(object):
         self.s3_reduced_redundancy = self._cfg('store reduced-redundancy')
         self.s3_path = self._cfg('store path')
         self.s3_date_prefix = self._cfg('store date-prefix')
+        self.s3_delete_retry_interval = \
+            self._cfg('store delete-retry-interval')
 
         seed_cfg = self.yml['tiles']['seed']
         self.seed_all_zoom_start = seed_cfg['all']['zoom-start']
@@ -151,6 +153,7 @@ def default_yml_config():
             'path': 'osm',
             'reduced-redundancy': False,
             'date-prefix': '',
+            'delete-retry-interval': 60,
         },
         'aws': {
             'credentials': {


### PR DESCRIPTION
The `delete_keys` method used to delete tiles from S3 returns an object containing both successes and failures, and does not raise an exception for failures. This means that rare or intermittent errors can result in some tiles not being deleted. Adding a retry mechanism should make sure that is not the case. Although the loop is infinite, the assumption is that errors from S3 are rare and that dealing with them this way is easier than adapting the API of the object to handle returning failure coordinates back to the main process.