### PR TITLE
Tidy things up for a data fetcher interface.

### DIFF
--- a/tilequeue/query/__init__.py
+++ b/tilequeue/query/__init__.py
@@ -1,0 +1,3 @@
+import tilequeue.query.postgres
+
+make_db_data_fetcher = postgres.make_db_data_fetcher

--- a/tilequeue/query/__init__.py
+++ b/tilequeue/query/__init__.py
@@ -1,3 +1,3 @@
 import tilequeue.query.postgres
 
-make_db_data_fetcher = postgres.make_db_data_fetcher
+make_db_data_fetcher = tilequeue.query.postgres.make_db_data_fetcher

--- a/tilequeue/query/__init__.py
+++ b/tilequeue/query/__init__.py
@@ -1,3 +1,3 @@
-import tilequeue.query.postgres
+from tilequeue.query import postgres
 
-make_db_data_fetcher = tilequeue.query.postgres.make_db_data_fetcher
+make_db_data_fetcher = postgres.make_db_data_fetcher


### PR DESCRIPTION
This is a small tidy-up to move a bunch of Jinja2 specific code into a module. The idea is that we can start separating the parts of the code which are specific to PostgreSQL from the general parts using the `DataFetcher` interface. Then we can implement additional things conforming to `DataFetcher`, such as RAWR tiles.