### PR TITLE
Fixture-based data source

### DIFF
--- a/tests/test_query_fixture.py
+++ b/tests/test_query_fixture.py
@@ -1,0 +1,44 @@
+import unittest
+
+
+class TestQueryFixture(unittest.TestCase):
+
+    def _make(self, rows, min_zoom_fn, props_fn):
+        from tilequeue.query.fixture import LayerInfo, DataFetcher
+        layers = {'testlayer': LayerInfo(min_zoom_fn, props_fn)}
+        return DataFetcher(layers, rows)
+
+    def test_query_simple(self):
+        from shapely.geometry import Point
+
+        def min_zoom_fn(shape, props, fid, meta):
+            return 5
+
+        def props_fn(shape, props, fid, meta):
+            return {'test': 'property'}
+
+        shape = Point(0, 0)
+        rows = [
+            (0, shape, {})
+        ]
+
+        fetch = self._make(rows, min_zoom_fn, props_fn)
+
+        # first, check that it can get the original item back when both the
+        # min zoom filter and geometry filter are okay.
+        read_rows = fetch(5, (-1, -1, 1, 1))
+
+        self.assertEquals(1, len(read_rows))
+        read_row = read_rows[0]
+        self.assertEquals(0, read_row.get('__id__'))
+        self.assertEquals(shape, read_row.get('__geometry__'))
+        self.assertEquals({'test': 'property', 'min_zoom': 5},
+                          read_row.get('__testlayer_properties__'))
+
+        # now, check that if the min zoom or geometry filters would exclude
+        # the feature then it isn't returned.
+        read_rows = fetch(4, (-1, -1, 1, 1))
+        self.assertEquals(0, len(read_rows))
+
+        read_rows = fetch(5, (1, 1, 2, 2))
+        self.assertEquals(0, len(read_rows))

--- a/tilequeue/query/__init__.py
+++ b/tilequeue/query/__init__.py
@@ -1,3 +1,4 @@
-from tilequeue.query import postgres
+from tilequeue.query import postgres, fixture
 
 make_db_data_fetcher = postgres.make_db_data_fetcher
+make_fixture_data_fetcher = fixture.make_data_fetcher

--- a/tilequeue/query/fixture.py
+++ b/tilequeue/query/fixture.py
@@ -1,0 +1,56 @@
+from collections import namedtuple
+from shapely.geometry import box
+
+
+LayerInfo = namedtuple('LayerInfo', 'min_zoom_fn props_fn')
+
+
+class DataFetcher(object):
+
+    def __init__(self, layers, rows):
+        """
+        Expect layers to be a dict of layer name to LayerInfo. Expect rows to
+        be a list of (fid, shape, properties).
+        """
+
+        self.layers = layers
+        self.rows = rows
+
+    def __call__(self, zoom, unpadded_bounds):
+        read_rows = []
+        bbox = box(*unpadded_bounds)
+
+        for (fid, shape, props) in self.rows:
+            # reject any feature which doesn't intersect the given bounds
+            if bbox.disjoint(shape):
+                continue
+
+            # place for assembing the read row as if from postgres
+            read_row = {}
+
+            for layer_name, info in self.layers.items():
+                # TODO: what should meta be?
+                meta = {}
+                min_zoom = info.min_zoom_fn(shape, props, fid, meta)
+
+                # reject anything which isn't in the current zoom range
+                if min_zoom is None or zoom < min_zoom:
+                    continue
+
+                layer_props = info.props_fn(shape, props, fid, meta)
+                layer_props['min_zoom'] = min_zoom
+                if layer_props:
+                    props_name = '__%s_properties__' % layer_name
+                    read_row[props_name] = layer_props
+
+            # if at least one min_zoom / properties match
+            if read_row:
+                read_row['__id__'] = fid
+                read_row['__geometry__'] = shape
+                read_rows.append(read_row)
+
+        return read_rows
+
+
+def make_data_fetcher(layers, rows):
+    return DataFetcher(layers, rows)


### PR DESCRIPTION
This adds a fixture-based data source, which returns data in a similar format to the data coming from PostgreSQL, so that it can be processed in the same way by the rest of the system. The idea is to use it for tests before widening the implementation to include RAWR tiles.

Starts to lay the foundation for tilezen/vector-datasource#923.