### PR TITLE
Add a tile status command

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -8,11 +8,11 @@ queue:
     # values are the queue name to use for zooms in that range
     0-10: queue-1
     11-20: queue-2
-statsd:
-  # Uncomment host to activate statsd
-  # host: 127.0.0.1
-  port: 8125
-  prefix: dev.tilequeue
+# Uncomment this section to activate statsd
+#statsd:
+#  host: 127.0.0.1
+#  port: 8125
+#  prefix: dev.tilequeue
 store:
   type: s3 # Can also be `directory`, which would dump the tiles to disk.
   name: <s3 bucket/tile directory name>

--- a/logging.conf.sample
+++ b/logging.conf.sample
@@ -1,5 +1,5 @@
 [loggers]
-keys=root,process,seed,intersect,drain,prune_tiles_of_interest,enqueue_tiles_of_interest,dump_tiles_of_interest,load_tiles_of_interest,wof_process_neighbourhoods,query,consume_tile_traffic
+keys=root,process,seed,intersect,drain,prune_tiles_of_interest,enqueue_tiles_of_interest,dump_tiles_of_interest,load_tiles_of_interest,wof_process_neighbourhoods,query,consume_tile_traffic,tile_status
 
 [handlers]
 keys=consoleHandler
@@ -75,6 +75,12 @@ propagate=0
 level=INFO
 handlers=consoleHandler
 qualName=consume_tile_traffic
+propagate=0
+
+[logger_tile_status]
+level=INFO
+handlers=consoleHandler
+qualName=tile_status
 propagate=0
 
 [handler_consoleHandler]

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -1547,12 +1547,12 @@ def tilequeue_tile_status(cfg, peripherals, args):
         # input checking! make sure that the coordinate is okay to use in
         # the rest of the code.
         if not coord:
-            logger.warning('Could not deserialize %r as coordinate' \
+            logger.warning('Could not deserialize %r as coordinate'
                            % (coord_str,))
             continue
 
         if not coord_is_valid(coord):
-            logger.warning('Coordinate is not valid: %r (parsed from %r)' \
+            logger.warning('Coordinate is not valid: %r (parsed from %r)'
                            % (coord, coord_str))
             continue
 
@@ -1567,7 +1567,7 @@ def tilequeue_tile_status(cfg, peripherals, args):
                 if callable(peripherals.queue._inflight):
                     is_inflight = peripherals.queue._inflight(coord_int)
                     logger.info('inflight: %r' % (is_inflight,))
-            except AttributeError, e:
+            except AttributeError:
                 logger.info('inflight: NOT SUPPORTED BY QUEUE')
 
         if peripherals.toi:
@@ -1645,6 +1645,7 @@ def tilequeue_main(argv_args=None):
     )
     for parser_name, func in parser_config:
         subparser = subparsers.add_parser(parser_name)
+
         def command_fn(cfg, peripherals, args):
             func(cfg, peripherals)
 

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -1560,6 +1560,7 @@ def tilequeue_tile_status(cfg, peripherals, args):
         # whether it exists in various places.
 
         logger.info("=== %s ===" % (coord_str,))
+        coord_int = coord_marshall_int(coord)
 
         if peripherals.queue:
             try:

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -1547,26 +1547,25 @@ def tilequeue_tile_status(cfg, peripherals, args):
         # input checking! make sure that the coordinate is okay to use in
         # the rest of the code.
         if not coord:
-            logger.warning('Could not deserialize %r as coordinate'
-                           % (coord_str,))
+            logger.warning('Could not deserialize %r as coordinate', coord_str)
             continue
 
         if not coord_is_valid(coord):
-            logger.warning('Coordinate is not valid: %r (parsed from %r)'
-                           % (coord, coord_str))
+            logger.warning('Coordinate is not valid: %r (parsed from %r)',
+                           coord, coord_str)
             continue
 
         # now we think we probably have a valid coordinate. go look up
         # whether it exists in various places.
 
-        logger.info("=== %s ===" % (coord_str,))
+        logger.info("=== %s ===", coord_str)
         coord_int = coord_marshall_int(coord)
 
         if peripherals.queue:
             try:
                 if callable(peripherals.queue._inflight):
                     is_inflight = peripherals.queue._inflight(coord_int)
-                    logger.info('inflight: %r' % (is_inflight,))
+                    logger.info('inflight: %r', is_inflight)
             except AttributeError:
                 logger.info('inflight: NOT SUPPORTED BY QUEUE')
 
@@ -1575,7 +1574,7 @@ def tilequeue_tile_status(cfg, peripherals, args):
             logger.info('in TOI: %r' % (in_toi,))
 
         data = store.read_tile(coord, tile_format, tile_layer)
-        logger.info('tile in store: %r' % (bool(data),))
+        logger.info('tile in store: %r', bool(data))
 
 
 class TileArgumentParser(argparse.ArgumentParser):


### PR DESCRIPTION
This command can be given a list of tiles and it will print out its in-flight, TOI and storage status. This can be helpful while debugging "stuck" tiles, although in the time it took me to write the tool, the issue [was probably self-fixed by the gardener](https://github.com/tilezen/vector-datasource/issues/1363#issuecomment-320227790).

I had to do some work-around-y stuff to pass the positional `coords` arguments to the `command_tile_status` function, so I'd very much appreciate any recommendations about how that might be done more neatly or cleanly.
