### PR TITLE
Add tilequeue command to list stuck tiles

### DIFF
--- a/logging.conf.sample
+++ b/logging.conf.sample
@@ -1,5 +1,5 @@
 [loggers]
-keys=root,process,seed,intersect,drain,prune_tiles_of_interest,enqueue_tiles_of_interest,dump_tiles_of_interest,load_tiles_of_interest,wof_process_neighbourhoods,query,consume_tile_traffic,tile_status
+keys=root,process,seed,intersect,drain,prune_tiles_of_interest,enqueue_tiles_of_interest,dump_tiles_of_interest,load_tiles_of_interest,wof_process_neighbourhoods,query,consume_tile_traffic,tile_status,stuck_tiles,delete_stuck_tiles
 
 [handlers]
 keys=consoleHandler
@@ -81,6 +81,18 @@ propagate=0
 level=INFO
 handlers=consoleHandler
 qualName=tile_status
+propagate=0
+
+[logger_stuck_tiles]
+level=INFO
+handlers=consoleHandler
+qualName=stuck_tiles
+propagate=0
+
+[logger_delete_stuck_tiles]
+level=INFO
+handlers=consoleHandler
+qualName=delete_stuck_tiles
 propagate=0
 
 [handler_consoleHandler]

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -1524,54 +1524,17 @@ def tilequeue_stuck_tiles(cfg, peripherals):
     """
     Check which files exist on s3 but are not in toi.
     """
-    logger = make_logger(cfg, 'stuck_tiles')
-
-    assert cfg.store_type == 's3', \
-        'Expecting an s3 store type, not %s' % cfg.store_type
-
-    bucket = cfg.s3_bucket
-    date_prefix = str(cfg.s3_date_prefix)
+    store = make_store(cfg.store_type, cfg.s3_bucket, cfg)
+    format = lookup_format_by_extension('zip')
+    layer = 'all'
 
     assert peripherals.toi, 'Missing toi'
     toi = peripherals.toi.fetch_tiles_of_interest()
 
-    import boto3
-    s3_client = boto3.client('s3', region_name='us-east-1')
-    paginator = s3_client.get_paginator('list_objects')
-
-    stuck_coords = set()
-    response_iterator = paginator.paginate(
-        Bucket=bucket,
-        Prefix=date_prefix,
-        PaginationConfig=dict(
-            PageSize=1000,
-        ),
-    )
-    for results in response_iterator:
-        status_code = results['ResponseMetadata']['HTTPStatusCode']
-        if status_code != 200:
-            logger.error('Invalid status code response: %s' % status_code)
-            break
-        for key_obj in results['Contents']:
-            key = key_obj['Key']
-            if key.endswith('.zip'):
-                fields = key.rsplit('/', 3)
-                if len(fields) == 4:
-                    _, z_str, x_str, y_fmt = fields
-                    y_str = y_fmt.split('.')[0]
-                    try:
-                        z = int(z_str)
-                        x = int(x_str)
-                        y = int(y_str)
-                        coord = Coordinate(zoom=z, column=x, row=y)
-                        coord_int = coord_marshall_int(coord)
-                        if coord_int not in toi:
-                            stuck_coords.add(coord_int)
-                    except ValueError:
-                        pass
-    for coord_int in stuck_coords:
-        coord = coord_unmarshall_int(coord_int)
-        print serialize_coord(coord)
+    for coord in store.list_tiles(format, layer):
+        coord_int = coord_marshall_int(coord)
+        if coord_int not in toi:
+            print serialize_coord(coord)
 
 
 def tilequeue_delete_stuck_tiles(cfg, peripherals):

--- a/tilequeue/store.py
+++ b/tilequeue/store.py
@@ -304,6 +304,12 @@ class Memory(object):
         tile_data, coord, format, layer = self.data
         return tile_data
 
+    def delete_tiles(self, coords, format, layer):
+        pass
+
+    def list_tiles(self, format, layer):
+        return [self.data] if self.data else []
+
 
 def make_s3_store(bucket_name,
                   aws_access_key_id=None, aws_secret_access_key=None,

--- a/tilequeue/store.py
+++ b/tilequeue/store.py
@@ -73,7 +73,7 @@ class S3(object):
     def delete_tiles(self, coords, format, layer):
         key_names = [
             s3_tile_key(self.date_prefix, self.path, layer, coord,
-                        format.extension)
+                        format.extension).lstrip('/')
             for coord in coords
         ]
 


### PR DESCRIPTION
Related to root cause analysis of https://github.com/tilezen/vector-datasource/issues/1363 and https://github.com/tilezen/vector-datasource/issues/1320. This new script will be used to list and then delete stuck tiles.

Followup will be filed relating to TOI Gardener config for root cause fix.