### PR TITLE
Support for local fixtures

### DIFF
--- a/tests/test_query_fixture.py
+++ b/tests/test_query_fixture.py
@@ -14,15 +14,12 @@ class TestQueryFixture(unittest.TestCase):
         def min_zoom_fn(shape, props, fid, meta):
             return 5
 
-        def props_fn(shape, props, fid, meta):
-            return {'test': 'property'}
-
         shape = Point(0, 0)
         rows = [
             (0, shape, {})
         ]
 
-        fetch = self._make(rows, min_zoom_fn, props_fn)
+        fetch = self._make(rows, min_zoom_fn, None)
 
         # first, check that it can get the original item back when both the
         # min zoom filter and geometry filter are okay.
@@ -31,8 +28,9 @@ class TestQueryFixture(unittest.TestCase):
         self.assertEquals(1, len(read_rows))
         read_row = read_rows[0]
         self.assertEquals(0, read_row.get('__id__'))
-        self.assertEquals(shape, read_row.get('__geometry__'))
-        self.assertEquals({'test': 'property', 'min_zoom': 5},
+        # query processing code expects WKB bytes in the __geometry__ column
+        self.assertEquals(shape.wkb, read_row.get('__geometry__'))
+        self.assertEquals({'min_zoom': 5},
                           read_row.get('__testlayer_properties__'))
 
         # now, check that if the min zoom or geometry filters would exclude

--- a/tests/test_query_fixture.py
+++ b/tests/test_query_fixture.py
@@ -41,3 +41,47 @@ class TestQueryFixture(unittest.TestCase):
 
         read_rows = fetch(5, (1, 1, 2, 2))
         self.assertEquals(0, len(read_rows))
+
+    def test_query_min_zoom_fraction(self):
+        from shapely.geometry import Point
+
+        def min_zoom_fn(shape, props, fid, meta):
+            return 4.999
+
+        shape = Point(0, 0)
+        rows = [
+            (0, shape, {})
+        ]
+
+        fetch = self._make(rows, min_zoom_fn, None)
+
+        # check that the fractional zoom of 4.999 means that it's included in
+        # the zoom 4 tile, but not the zoom 3 one.
+        read_rows = fetch(4, (-1, -1, 1, 1))
+        self.assertEquals(1, len(read_rows))
+
+        read_rows = fetch(3, (-1, -1, 1, 1))
+        self.assertEquals(0, len(read_rows))
+
+    def test_query_past_max_zoom(self):
+        from shapely.geometry import Point
+
+        def min_zoom_fn(shape, props, fid, meta):
+            return 20
+
+        shape = Point(0, 0)
+        rows = [
+            (0, shape, {})
+        ]
+
+        fetch = self._make(rows, min_zoom_fn, None)
+
+        # the min_zoom of 20 should mean that the feature is included at zoom
+        # 16, even though 16<20, because 16 is the "max zoom" at which all the
+        # data is included.
+        read_rows = fetch(16, (-1, -1, 1, 1))
+        self.assertEquals(1, len(read_rows))
+
+        # but it should not exist at zoom 15
+        read_rows = fetch(15, (-1, -1, 1, 1))
+        self.assertEquals(0, len(read_rows))

--- a/tests/test_query_fixture.py
+++ b/tests/test_query_fixture.py
@@ -4,9 +4,10 @@ import unittest
 class TestQueryFixture(unittest.TestCase):
 
     def _make(self, rows, min_zoom_fn, props_fn):
-        from tilequeue.query.fixture import LayerInfo, DataFetcher
+        from tilequeue.query.fixture import LayerInfo
+        from tilequeue.query.fixture import make_fixture_data_fetcher
         layers = {'testlayer': LayerInfo(min_zoom_fn, props_fn)}
-        return DataFetcher(layers, rows)
+        return make_fixture_data_fetcher(layers, rows)
 
     def test_query_simple(self):
         from shapely.geometry import Point

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -237,8 +237,7 @@ def meta_for_properties(query_props):
     query_props_source = query_props.get('source')
     if query_props_source:
         source = lookup_source(query_props_source)
-        if not source:
-            assert 0, 'Unknown source: %s' % query_props_source
+        assert source, 'Unknown source: %s' % query_props_source
         meta = make_metadata(source)
     return meta
 

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -232,6 +232,17 @@ def lookup_source(source):
     return result
 
 
+def meta_for_properties(query_props):
+    meta = None
+    query_props_source = query_props.get('source')
+    if query_props_source:
+        source = lookup_source(query_props_source)
+        if not source:
+            assert 0, 'Unknown source: %s' % query_props_source
+        meta = make_metadata(source)
+    return meta
+
+
 def process_coord_no_format(
         feature_layers, nominal_zoom, unpadded_bounds, post_process_data,
         output_calc_mapping):
@@ -312,13 +323,7 @@ def process_coord_no_format(
             # This is done in python here to avoid having to update
             # all the queries in the jinja file with redundant
             # information.
-            meta = None
-            query_props_source = query_props.get('source')
-            if query_props_source:
-                source = lookup_source(query_props_source)
-                if not source:
-                    assert 0, 'Unknown source: %s' % query_props_source
-                meta = make_metadata(source)
+            meta = meta_for_properties(query_props)
 
             # set the "tags" key
             # some transforms expect to be able to read it from this location

--- a/tilequeue/query/__init__.py
+++ b/tilequeue/query/__init__.py
@@ -1,9 +1,6 @@
-from tilequeue.query.fixture import make_data_fetcher
+from tilequeue.query.fixture import make_fixture_data_fetcher
 from tilequeue.query.pool import DBConnectionPool
 from tilequeue.query.postgres import make_db_data_fetcher
-
-# expose the fixture data fetcher under a different name
-make_fixture_data_fetcher = make_data_fetcher
 
 __all__ = [
     'DBConnectionPool',

--- a/tilequeue/query/fixture.py
+++ b/tilequeue/query/fixture.py
@@ -8,14 +8,16 @@ LayerInfo = namedtuple('LayerInfo', 'min_zoom_fn props_fn')
 
 class DataFetcher(object):
 
-    def __init__(self, layers, rows):
+    def __init__(self, layers, rows, label_placement_layers):
         """
         Expect layers to be a dict of layer name to LayerInfo. Expect rows to
-        be a list of (fid, shape, properties).
+        be a list of (fid, shape, properties). Label placement layers should
+        be a set of layer names for which to generate label placement points.
         """
 
         self.layers = layers
         self.rows = rows
+        self.label_placement_layers = label_placement_layers
 
     def __call__(self, zoom, unpadded_bounds):
         read_rows = []
@@ -29,6 +31,9 @@ class DataFetcher(object):
             # place for assembing the read row as if from postgres
             read_row = {}
 
+            # whether to generate a label placement centroid
+            generate_label_placement = False
+
             for layer_name, info in self.layers.items():
                 meta = meta_for_properties(props)
                 min_zoom = info.min_zoom_fn(shape, props, fid, meta)
@@ -36,6 +41,11 @@ class DataFetcher(object):
                 # reject anything which isn't in the current zoom range
                 if min_zoom is None or zoom < min_zoom:
                     continue
+
+                # if the feature exists in any label placement layer, then we
+                # should consider generating a centroid (if it's a polygon)
+                if layer_name in self.label_placement_layers:
+                    generate_label_placement = True
 
                 layer_props = props.copy()
                 layer_props['min_zoom'] = min_zoom
@@ -47,10 +57,14 @@ class DataFetcher(object):
             if read_row:
                 read_row['__id__'] = fid
                 read_row['__geometry__'] = bytes(shape.wkb)
+                if shape.geom_type in ('Polygon', 'MultiPolygon') and \
+                   generate_label_placement:
+                    read_row['__label__'] = bytes(
+                        shape.representative_point().wkb)
                 read_rows.append(read_row)
 
         return read_rows
 
 
-def make_data_fetcher(layers, rows):
-    return DataFetcher(layers, rows)
+def make_fixture_data_fetcher(layers, rows, label_placement_layers=set()):
+    return DataFetcher(layers, rows, label_placement_layers)

--- a/tilequeue/query/fixture.py
+++ b/tilequeue/query/fixture.py
@@ -73,10 +73,17 @@ class DataFetcher(object):
                 meta = Metadata(source, ways, rels)
                 min_zoom = info.min_zoom_fn(shape, props, fid, meta)
 
+                # reject features which don't match in this layer
+                if min_zoom is None:
+                    continue
+
                 # reject anything which isn't in the current zoom range
                 # note that this is (zoom+1) because things with a min_zoom of
                 # (e.g) 14.999 should still be in the zoom 14 tile.
-                if min_zoom is None or (zoom + 1) < min_zoom:
+                #
+                # also, if zoom >= 16, we should include all features, even
+                # those with min_zoom > zoom.
+                if zoom < 16 and (zoom + 1) <= min_zoom:
                     continue
 
                 # if the feature exists in any label placement layer, then we

--- a/tilequeue/query/fixture.py
+++ b/tilequeue/query/fixture.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 from shapely.geometry import box
+from tilequeue.process import meta_for_properties
 
 
 LayerInfo = namedtuple('LayerInfo', 'min_zoom_fn props_fn')
@@ -29,15 +30,14 @@ class DataFetcher(object):
             read_row = {}
 
             for layer_name, info in self.layers.items():
-                # TODO: what should meta be?
-                meta = {}
+                meta = meta_for_properties(props)
                 min_zoom = info.min_zoom_fn(shape, props, fid, meta)
 
                 # reject anything which isn't in the current zoom range
                 if min_zoom is None or zoom < min_zoom:
                     continue
 
-                layer_props = info.props_fn(shape, props, fid, meta)
+                layer_props = props.copy()
                 layer_props['min_zoom'] = min_zoom
                 if layer_props:
                     props_name = '__%s_properties__' % layer_name
@@ -46,7 +46,7 @@ class DataFetcher(object):
             # if at least one min_zoom / properties match
             if read_row:
                 read_row['__id__'] = fid
-                read_row['__geometry__'] = shape
+                read_row['__geometry__'] = bytes(shape.wkb)
                 read_rows.append(read_row)
 
         return read_rows

--- a/tilequeue/query/fixture.py
+++ b/tilequeue/query/fixture.py
@@ -124,6 +124,17 @@ class DataFetcher(object):
                 if zoom < 16 and (zoom + 1) <= min_zoom:
                     continue
 
+                # UGLY HACK: match the query for "max zoom" for NE places.
+                # this removes larger cities at low zooms, and smaller cities
+                # as the zoom increases and as the OSM cities start to "fade
+                # in".
+                if props.get('source') == 'naturalearthdata.com':
+                    pop_max = int(props.get('pop_max', '0'))
+                    if ((zoom >= 8 and zoom < 10 and pop_max > 50000) or
+                        (zoom >= 10 and zoom < 11 and pop_max > 20000) or
+                        (zoom >= 11 and pop_max > 5000)):
+                        continue
+
                 # if the feature exists in any label placement layer, then we
                 # should consider generating a centroid
                 label_layers = self.label_placement_layers.get(

--- a/tilequeue/query/fixture.py
+++ b/tilequeue/query/fixture.py
@@ -49,6 +49,11 @@ class DataFetcher(object):
 
                 layer_props = props.copy()
                 layer_props['min_zoom'] = min_zoom
+
+                # urgh, hack!
+                if layer_name == 'water' and shape.geom_type == 'Point':
+                    layer_props['label_placement'] = True
+
                 if layer_props:
                     props_name = '__%s_properties__' % layer_name
                     read_row[props_name] = layer_props

--- a/tilequeue/query/fixture.py
+++ b/tilequeue/query/fixture.py
@@ -55,6 +55,10 @@ class DataFetcher(object):
             if bbox.disjoint(shape):
                 continue
 
+            # copy props so that any updates to it don't affect the original
+            # data.
+            props = props.copy()
+
             # TODO: there must be some better way of doing this?
             rels = props.pop('__relations__', [])
             ways = props.pop('__ways__', [])

--- a/tilequeue/query/fixture.py
+++ b/tilequeue/query/fixture.py
@@ -130,9 +130,10 @@ class DataFetcher(object):
                 # in".
                 if props.get('source') == 'naturalearthdata.com':
                     pop_max = int(props.get('pop_max', '0'))
-                    if ((zoom >= 8 and zoom < 10 and pop_max > 50000) or
-                        (zoom >= 10 and zoom < 11 and pop_max > 20000) or
-                        (zoom >= 11 and pop_max > 5000)):
+                    remove = ((zoom >= 8 and zoom < 10 and pop_max > 50000) or
+                              (zoom >= 10 and zoom < 11 and pop_max > 20000) or
+                              (zoom >= 11 and pop_max > 5000))
+                    if remove:
                         continue
 
                 # if the feature exists in any label placement layer, then we

--- a/tilequeue/query/fixture.py
+++ b/tilequeue/query/fixture.py
@@ -149,7 +149,15 @@ def mz_calculate_transit_routes_and_score(rows, node_id, way_id):
 
     # TODO: if the station is also a multipolygon relation?
 
-    # TODO:
+    # TODO: the following hasn't been implemented because the way that the
+    # code currently collects the list of relations misses out any relations
+    # which aren't immediate parents of something with physical geometry. this
+    # means that, for example, the "root" relation of London Waterloo station
+    # (type=site, site=stop_area) doesn't get included. (see vector-datasource
+    # integration test 653). possibly this can be fixed by passing the
+    # original list of relations in, rather than having them pre-assigned to
+    # features?
+    #
     # this complex query does two recursive sweeps of the relations
     # table starting from a seed set of relations which are or contain
     # the original station.

--- a/tilequeue/query/fixture.py
+++ b/tilequeue/query/fixture.py
@@ -74,7 +74,9 @@ class DataFetcher(object):
                 min_zoom = info.min_zoom_fn(shape, props, fid, meta)
 
                 # reject anything which isn't in the current zoom range
-                if min_zoom is None or zoom < min_zoom:
+                # note that this is (zoom+1) because things with a min_zoom of
+                # (e.g) 14.999 should still be in the zoom 14 tile.
+                if min_zoom is None or (zoom + 1) < min_zoom:
                     continue
 
                 # if the feature exists in any label placement layer, then we
@@ -88,6 +90,9 @@ class DataFetcher(object):
                 # urgh, hack!
                 if layer_name == 'water' and shape.geom_type == 'Point':
                     layer_props['label_placement'] = True
+
+                if shape.geom_type in ('Polygon', 'MultiPolygon'):
+                    layer_props['area'] = shape.area
 
                 if layer_name == 'roads' and \
                    shape.geom_type in ('LineString', 'MultiLineString'):

--- a/tilequeue/tile.py
+++ b/tilequeue/tile.py
@@ -101,6 +101,10 @@ def reproject_lnglat_to_mercator(x, y, *unused_coords):
     return pyproj.transform(latlng_proj, merc_proj, x, y)
 
 
+def reproject_mercator_to_lnglat(x, y, *unused_coords):
+    return pyproj.transform(merc_proj, latlng_proj, x, y)
+
+
 # mercator <-> point conversions ported from tilestache
 earth_radius = 6378137
 earth_circum = 2 * math.pi * earth_radius


### PR DESCRIPTION
This is mostly changes to the "fixture DataFetcher" to make the same transforms as are being done by the PostgreSQL queries. This is enough to support running all but one integration test from the vector-datasource repo. (The one which still fails is due to station relation walking not yet being implemented well enough to handle the `root_relation_id` stuff.)

There are a few TODOs left here, but it's already getting to be a big patch, so I'd like to see what you think before going any further.
