### PR TITLE
Add option to pass all relations to fixture data fetcher.

### DIFF
--- a/tests/test_query_fixture.py
+++ b/tests/test_query_fixture.py
@@ -102,7 +102,6 @@ class TestQueryFixture(unittest.TestCase):
                 }),
             ]
 
-
             fetch = self._make(rows, min_zoom_fn, None, relations=rels,
                                layer_name='pois')
 
@@ -140,5 +139,5 @@ class TestQueryFixture(unittest.TestCase):
             _rel(2, nodes=[1]),
             _rel(3, nodes=[1]),
             _rel(4, rels=[3]),
-            _rel(5, rels=[2,4]),
+            _rel(5, rels=[2, 4]),
         ], 5)

--- a/tests/test_query_fixture.py
+++ b/tests/test_query_fixture.py
@@ -3,11 +3,12 @@ import unittest
 
 class TestQueryFixture(unittest.TestCase):
 
-    def _make(self, rows, min_zoom_fn, props_fn):
+    def _make(self, rows, min_zoom_fn, props_fn, relations=[],
+              layer_name='testlayer'):
         from tilequeue.query.fixture import LayerInfo
         from tilequeue.query.fixture import make_fixture_data_fetcher
-        layers = {'testlayer': LayerInfo(min_zoom_fn, props_fn)}
-        return make_fixture_data_fetcher(layers, rows)
+        layers = {layer_name: LayerInfo(min_zoom_fn, props_fn)}
+        return make_fixture_data_fetcher(layers, rows, relations=relations)
 
     def test_query_simple(self):
         from shapely.geometry import Point
@@ -85,3 +86,59 @@ class TestQueryFixture(unittest.TestCase):
         # but it should not exist at zoom 15
         read_rows = fetch(15, (-1, -1, 1, 1))
         self.assertEquals(0, len(read_rows))
+
+    def test_root_relation_id(self):
+        from shapely.geometry import Point
+
+        def min_zoom_fn(shape, props, fid, meta):
+            return 0
+
+        def _test(rels, expected_root_id):
+            shape = Point(0, 0)
+            rows = [
+                (1, shape, {
+                    'railway': 'station',
+                    'name': 'Foo Station',
+                }),
+            ]
+
+
+            fetch = self._make(rows, min_zoom_fn, None, relations=rels,
+                               layer_name='pois')
+
+            read_rows = fetch(16, (-1, -1, 1, 1))
+            self.assertEquals(1, len(read_rows))
+
+            props = read_rows[0]['__pois_properties__']
+            self.assertEquals(expected_root_id,
+                              props.get('mz_transit_root_relation_id'))
+
+        # the fixture code expects "raw" relations as if they come straight
+        # from osm2pgsql. the structure is a little cumbersome, so this
+        # utility function constructs it from a more readable function call.
+        def _rel(id, nodes=None, ways=None, rels=None):
+            way_off = len(nodes) if nodes else 0
+            rel_off = way_off + (len(ways) if ways else 0)
+            return {
+                'id': id,
+                'tags': ['type', 'site'],
+                'way_off': way_off,
+                'rel_off': rel_off,
+                'parts': (nodes or []) + (ways or []) + (rels or []),
+            }
+
+        # one level of relations - this one directly contains the station
+        # node.
+        _test([_rel(2, nodes=[1])], 2)
+
+        # two levels of relations r3 contains r2 contains n1.
+        _test([_rel(2, nodes=[1]), _rel(3, rels=[2])], 3)
+
+        # asymmetric diamond pattern. r2 and r3 both contain n1, r4 contains
+        # r3 and r5 contains both r4 and r2, making it the "top" relation.
+        _test([
+            _rel(2, nodes=[1]),
+            _rel(3, nodes=[1]),
+            _rel(4, rels=[3]),
+            _rel(5, rels=[2,4]),
+        ], 5)


### PR DESCRIPTION
This is used to recurse up through transit relations to find the "root" transit relation ID, which can be used to group together all the features which are part of the "same" station.

Related: https://github.com/tilezen/vector-datasource/issues/1392