### PR TITLE
Remove unused commands

### DIFF
--- a/logging.conf.sample
+++ b/logging.conf.sample
@@ -1,5 +1,5 @@
 [loggers]
-keys=root,process,seed,drain,prune_tiles_of_interest,enqueue_tiles_of_interest,dump_tiles_of_interest,load_tiles_of_interest,wof_process_neighbourhoods,query,consume_tile_traffic,tile_status,stuck_tiles,delete_stuck_tiles,rawr_enqueue,rawr_process
+keys=root,process,seed,prune_tiles_of_interest,enqueue_tiles_of_interest,dump_tiles_of_interest,load_tiles_of_interest,wof_process_neighbourhoods,query,consume_tile_traffic,tile_status,stuck_tiles,delete_stuck_tiles,rawr_enqueue,rawr_process
 
 [handlers]
 keys=consoleHandler
@@ -45,12 +45,6 @@ propagate=0
 level=INFO
 handlers=consoleHandler
 qualName=seed
-propagate=0
-
-[logger_drain]
-level=INFO
-handlers=consoleHandler
-qualName=drain
 propagate=0
 
 [logger_wof_process_neighbourhoods]


### PR DESCRIPTION
In preparation for updating logging, I noticed that some commands that were either very old or never been run, ie dead code. Some of these were using loggers, so now seems like as good a time as any to remove them.