### PR TITLE
Hook up RAWR data fetcher

### DIFF
--- a/tests/test_metatile.py
+++ b/tests/test_metatile.py
@@ -111,48 +111,48 @@ class TestMetatile(unittest.TestCase):
             metatile_1[0]['tile'], metatile_2[0]['tile']))
 
     def test_metatile_common_parent(self):
-        from tilequeue.metatile import _common_parent
+        from tilequeue.metatile import common_parent
 
         def tile(z, x, y):
             return Coordinate(zoom=z, column=x, row=y)
 
         self.assertEqual(
             tile(0, 0, 0),
-            _common_parent(tile(1, 1, 1), tile(1, 0, 0)))
+            common_parent(tile(1, 1, 1), tile(1, 0, 0)))
 
         self.assertEqual(
             tile(0, 0, 0),
-            _common_parent(tile(0, 0, 0), tile(1, 0, 0)))
+            common_parent(tile(0, 0, 0), tile(1, 0, 0)))
         self.assertEqual(
             tile(0, 0, 0),
-            _common_parent(tile(1, 0, 0), tile(0, 0, 0)))
+            common_parent(tile(1, 0, 0), tile(0, 0, 0)))
 
         self.assertEqual(
             tile(0, 0, 0),
-            _common_parent(tile(2, 0, 0), tile(2, 3, 3)))
+            common_parent(tile(2, 0, 0), tile(2, 3, 3)))
         self.assertEqual(
             tile(0, 0, 0),
-            _common_parent(tile(3, 0, 0), tile(3, 7, 7)))
+            common_parent(tile(3, 0, 0), tile(3, 7, 7)))
         self.assertEqual(
             tile(0, 0, 0),
-            _common_parent(tile(4, 0, 0), tile(4, 15, 15)))
+            common_parent(tile(4, 0, 0), tile(4, 15, 15)))
 
         self.assertEqual(
             tile(0, 0, 0),
-            _common_parent(tile(3, 3, 3), tile(2, 3, 3)))
+            common_parent(tile(3, 3, 3), tile(2, 3, 3)))
         self.assertEqual(
             tile(0, 0, 0),
-            _common_parent(tile(4, 7, 7), tile(3, 7, 7)))
+            common_parent(tile(4, 7, 7), tile(3, 7, 7)))
         self.assertEqual(
             tile(0, 0, 0),
-            _common_parent(tile(5, 15, 15), tile(4, 15, 15)))
+            common_parent(tile(5, 15, 15), tile(4, 15, 15)))
 
         self.assertEqual(
             tile(1, 1, 1),
-            _common_parent(tile(3, 4, 4), tile(2, 3, 3)))
+            common_parent(tile(3, 4, 4), tile(2, 3, 3)))
         self.assertEqual(
             tile(1, 1, 1),
-            _common_parent(tile(4, 8, 8), tile(3, 7, 7)))
+            common_parent(tile(4, 8, 8), tile(3, 7, 7)))
         self.assertEqual(
             tile(1, 1, 1),
-            _common_parent(tile(5, 16, 16), tile(4, 15, 15)))
+            common_parent(tile(5, 16, 16), tile(4, 15, 15)))

--- a/tests/test_query_rawr.py
+++ b/tests/test_query_rawr.py
@@ -79,7 +79,7 @@ class TestQueryRawr(RawrTestCase):
         # min zoom filter and geometry filter are okay.
         feature_coord = mercator_point_to_coord(
             feature_min_zoom, shape.x, shape.y)
-        with fetch.start(coord) as fetcher:
+        for fetcher in fetch.start([coord]):
             read_rows = fetcher(
                 feature_min_zoom, coord_to_mercator_bounds(feature_coord))
 
@@ -93,11 +93,11 @@ class TestQueryRawr(RawrTestCase):
 
         # now, check that if the min zoom or geometry filters would exclude
         # the feature then it isn't returned.
-        with fetch.start(coord) as fetcher:
+        for fetcher in fetch.start([coord]):
             read_rows = fetcher(zoom, coord_to_mercator_bounds(coord))
         self.assertEquals(0, len(read_rows))
 
-        with fetch.start(coord) as fetcher:
+        for fetcher in fetch.start([coord]):
             read_rows = fetcher(
                 feature_min_zoom, coord_to_mercator_bounds(
                     feature_coord.left()))
@@ -131,12 +131,12 @@ class TestQueryRawr(RawrTestCase):
         # check that the fractional zoom of 11.999 means that it's included in
         # the zoom 11 tile, but not the zoom 10 one.
         feature_coord = mercator_point_to_coord(11, shape.x, shape.y)
-        with fetcher.start(coord) as fetch:
+        for fetch in fetcher.start([coord]):
             read_rows = fetch(11, coord_to_mercator_bounds(feature_coord))
         self.assertEquals(1, len(read_rows))
 
         feature_coord = feature_coord.zoomBy(-1).container()
-        with fetcher.start(coord) as fetch:
+        for fetch in fetcher.start([coord]):
             read_rows = fetch(10, coord_to_mercator_bounds(feature_coord))
         self.assertEquals(0, len(read_rows))
 
@@ -169,13 +169,13 @@ class TestQueryRawr(RawrTestCase):
         # 16, even though 16<20, because 16 is the "max zoom" at which all the
         # data is included.
         feature_coord = mercator_point_to_coord(16, shape.x, shape.y)
-        with fetch.start(coord) as fetcher:
+        for fetcher in fetch.start([coord]):
             read_rows = fetcher(16, coord_to_mercator_bounds(feature_coord))
         self.assertEquals(1, len(read_rows))
 
         # but it should not exist at zoom 15
         feature_coord = feature_coord.zoomBy(-1).container()
-        with fetch.start(coord) as fetcher:
+        for fetcher in fetch.start([coord]):
             read_rows = fetcher(10, coord_to_mercator_bounds(feature_coord))
         self.assertEquals(0, len(read_rows))
 
@@ -210,7 +210,7 @@ class TestQueryRawr(RawrTestCase):
                                layer_name='pois')
 
             feature_coord = mercator_point_to_coord(16, shape.x, shape.y)
-            with fetch.start(coord) as fetcher:
+            for fetcher in fetch.start([coord]):
                 read_rows = fetcher(16, coord_to_mercator_bounds(
                     feature_coord))
             self.assertEquals(1, len(read_rows))
@@ -281,7 +281,7 @@ class TestLabelPlacement(RawrTestCase):
             min_zoom_fn, None, tables, tile_pyramid, layer_name=layer_name,
             label_placement_layers=label_placement_layers)
 
-        with fetch.start(top_tile) as fetcher:
+        for fetcher in fetch.start([top_tile]):
             read_rows = fetcher(tile.zoom, bounds)
         return read_rows
 
@@ -340,7 +340,7 @@ class TestGeometryClipping(RawrTestCase):
         fetch = self._make(
             min_zoom_fn, None, tables, tile_pyramid, layer_name=layer_name)
 
-        with fetch.start(top_tile) as fetcher:
+        for fetcher in fetch.start([top_tile]):
             read_rows = fetcher(tile.zoom, bounds)
         self.assertEqual(1, len(read_rows))
         return read_rows[0]
@@ -426,7 +426,7 @@ class TestNameHandling(RawrTestCase):
         fetch = make_rawr_data_fetcher(
             top_zoom, max_zoom, storage, layers, source)
 
-        with fetch.start(top_tile) as fetcher:
+        for fetcher in fetch.start([top_tile]):
             read_rows = fetcher(tile.zoom, coord_to_mercator_bounds(tile))
         # the RAWR query goes over features multiple times because of the
         # indexing, so we can't rely on all the properties for one feature to
@@ -528,7 +528,7 @@ class TestMeta(RawrTestCase):
         # min zoom filter and geometry filter are okay.
         feature_coord = mercator_point_to_coord(
             feature_min_zoom, shape.x, shape.y)
-        with fetch.start(coord) as fetcher:
+        for fetcher in fetch.start([coord]):
             read_rows = fetcher(
                 feature_min_zoom, coord_to_mercator_bounds(feature_coord))
 
@@ -597,7 +597,7 @@ class TestMeta(RawrTestCase):
         # min zoom filter and geometry filter are okay.
         feature_coord = mercator_point_to_coord(
             feature_min_zoom, *shape.coords[0])
-        with fetch.start(coord) as fetcher:
+        for fetcher in fetch.start([coord]):
             read_rows = fetcher(
                 feature_min_zoom, coord_to_mercator_bounds(feature_coord))
 

--- a/tests/test_query_rawr.py
+++ b/tests/test_query_rawr.py
@@ -45,6 +45,14 @@ class RawrTestCase(unittest.TestCase):
             label_placement_layers=label_placement_layers)
 
 
+# the call to DataFetcher.start wants a list of "data" dictionaries, each with
+# a 'coord' key. this utility function just repackages a single coordinate in
+# the way it wants.
+def _wrap(coord):
+    data = dict(coord=coord)
+    return [data]
+
+
 class TestQueryRawr(RawrTestCase):
 
     def test_query_simple(self):
@@ -79,7 +87,7 @@ class TestQueryRawr(RawrTestCase):
         # min zoom filter and geometry filter are okay.
         feature_coord = mercator_point_to_coord(
             feature_min_zoom, shape.x, shape.y)
-        for fetcher in fetch.start([coord]):
+        for fetcher, _ in fetch.start(_wrap(coord)):
             read_rows = fetcher(
                 feature_min_zoom, coord_to_mercator_bounds(feature_coord))
 
@@ -93,11 +101,11 @@ class TestQueryRawr(RawrTestCase):
 
         # now, check that if the min zoom or geometry filters would exclude
         # the feature then it isn't returned.
-        for fetcher in fetch.start([coord]):
+        for fetcher, _ in fetch.start(_wrap(coord)):
             read_rows = fetcher(zoom, coord_to_mercator_bounds(coord))
         self.assertEquals(0, len(read_rows))
 
-        for fetcher in fetch.start([coord]):
+        for fetcher, _ in fetch.start(_wrap(coord)):
             read_rows = fetcher(
                 feature_min_zoom, coord_to_mercator_bounds(
                     feature_coord.left()))
@@ -131,12 +139,12 @@ class TestQueryRawr(RawrTestCase):
         # check that the fractional zoom of 11.999 means that it's included in
         # the zoom 11 tile, but not the zoom 10 one.
         feature_coord = mercator_point_to_coord(11, shape.x, shape.y)
-        for fetch in fetcher.start([coord]):
+        for fetch, _ in fetcher.start(_wrap(coord)):
             read_rows = fetch(11, coord_to_mercator_bounds(feature_coord))
         self.assertEquals(1, len(read_rows))
 
         feature_coord = feature_coord.zoomBy(-1).container()
-        for fetch in fetcher.start([coord]):
+        for fetch, _ in fetcher.start(_wrap(coord)):
             read_rows = fetch(10, coord_to_mercator_bounds(feature_coord))
         self.assertEquals(0, len(read_rows))
 
@@ -169,13 +177,13 @@ class TestQueryRawr(RawrTestCase):
         # 16, even though 16<20, because 16 is the "max zoom" at which all the
         # data is included.
         feature_coord = mercator_point_to_coord(16, shape.x, shape.y)
-        for fetcher in fetch.start([coord]):
+        for fetcher, _ in fetch.start(_wrap(coord)):
             read_rows = fetcher(16, coord_to_mercator_bounds(feature_coord))
         self.assertEquals(1, len(read_rows))
 
         # but it should not exist at zoom 15
         feature_coord = feature_coord.zoomBy(-1).container()
-        for fetcher in fetch.start([coord]):
+        for fetcher, _ in fetch.start(_wrap(coord)):
             read_rows = fetcher(10, coord_to_mercator_bounds(feature_coord))
         self.assertEquals(0, len(read_rows))
 
@@ -210,7 +218,7 @@ class TestQueryRawr(RawrTestCase):
                                layer_name='pois')
 
             feature_coord = mercator_point_to_coord(16, shape.x, shape.y)
-            for fetcher in fetch.start([coord]):
+            for fetcher, _ in fetch.start(_wrap(coord)):
                 read_rows = fetcher(16, coord_to_mercator_bounds(
                     feature_coord))
             self.assertEquals(1, len(read_rows))
@@ -281,7 +289,7 @@ class TestLabelPlacement(RawrTestCase):
             min_zoom_fn, None, tables, tile_pyramid, layer_name=layer_name,
             label_placement_layers=label_placement_layers)
 
-        for fetcher in fetch.start([top_tile]):
+        for fetcher, _ in fetch.start(_wrap(top_tile)):
             read_rows = fetcher(tile.zoom, bounds)
         return read_rows
 
@@ -340,7 +348,7 @@ class TestGeometryClipping(RawrTestCase):
         fetch = self._make(
             min_zoom_fn, None, tables, tile_pyramid, layer_name=layer_name)
 
-        for fetcher in fetch.start([top_tile]):
+        for fetcher, _ in fetch.start(_wrap(top_tile)):
             read_rows = fetcher(tile.zoom, bounds)
         self.assertEqual(1, len(read_rows))
         return read_rows[0]
@@ -426,7 +434,7 @@ class TestNameHandling(RawrTestCase):
         fetch = make_rawr_data_fetcher(
             top_zoom, max_zoom, storage, layers, source)
 
-        for fetcher in fetch.start([top_tile]):
+        for fetcher, _ in fetch.start(_wrap(top_tile)):
             read_rows = fetcher(tile.zoom, coord_to_mercator_bounds(tile))
         # the RAWR query goes over features multiple times because of the
         # indexing, so we can't rely on all the properties for one feature to
@@ -528,7 +536,7 @@ class TestMeta(RawrTestCase):
         # min zoom filter and geometry filter are okay.
         feature_coord = mercator_point_to_coord(
             feature_min_zoom, shape.x, shape.y)
-        for fetcher in fetch.start([coord]):
+        for fetcher, _ in fetch.start(_wrap(coord)):
             read_rows = fetcher(
                 feature_min_zoom, coord_to_mercator_bounds(feature_coord))
 
@@ -597,7 +605,7 @@ class TestMeta(RawrTestCase):
         # min zoom filter and geometry filter are okay.
         feature_coord = mercator_point_to_coord(
             feature_min_zoom, *shape.coords[0])
-        for fetcher in fetch.start([coord]):
+        for fetcher, _ in fetch.start(_wrap(coord)):
             read_rows = fetcher(
                 feature_min_zoom, coord_to_mercator_bounds(feature_coord))
 

--- a/tests/test_query_rawr.py
+++ b/tests/test_query_rawr.py
@@ -43,9 +43,9 @@ class RawrTestCase(unittest.TestCase):
             label_placement_layers=label_placement_layers)
 
 
-# the call to DataFetcher.start wants a list of "data" dictionaries, each with
-# a 'coord' key. this utility function just repackages a single coordinate in
-# the way it wants.
+# the call to DataFetcher.fetch_tiles wants a list of "data" dictionaries,
+# each with a 'coord' key. this utility function just repackages a single
+# coordinate in the way it wants.
 def _wrap(coord):
     data = dict(coord=coord)
     return [data]
@@ -85,7 +85,7 @@ class TestQueryRawr(RawrTestCase):
         # min zoom filter and geometry filter are okay.
         feature_coord = mercator_point_to_coord(
             feature_min_zoom, shape.x, shape.y)
-        for fetcher, _ in fetch.start(_wrap(coord)):
+        for fetcher, _ in fetch.fetch_tiles(_wrap(coord)):
             read_rows = fetcher(
                 feature_min_zoom, coord_to_mercator_bounds(feature_coord))
 
@@ -99,11 +99,11 @@ class TestQueryRawr(RawrTestCase):
 
         # now, check that if the min zoom or geometry filters would exclude
         # the feature then it isn't returned.
-        for fetcher, _ in fetch.start(_wrap(coord)):
+        for fetcher, _ in fetch.fetch_tiles(_wrap(coord)):
             read_rows = fetcher(zoom, coord_to_mercator_bounds(coord))
         self.assertEquals(0, len(read_rows))
 
-        for fetcher, _ in fetch.start(_wrap(coord)):
+        for fetcher, _ in fetch.fetch_tiles(_wrap(coord)):
             read_rows = fetcher(
                 feature_min_zoom, coord_to_mercator_bounds(
                     feature_coord.left()))
@@ -137,12 +137,12 @@ class TestQueryRawr(RawrTestCase):
         # check that the fractional zoom of 11.999 means that it's included in
         # the zoom 11 tile, but not the zoom 10 one.
         feature_coord = mercator_point_to_coord(11, shape.x, shape.y)
-        for fetch, _ in fetcher.start(_wrap(coord)):
+        for fetch, _ in fetcher.fetch_tiles(_wrap(coord)):
             read_rows = fetch(11, coord_to_mercator_bounds(feature_coord))
         self.assertEquals(1, len(read_rows))
 
         feature_coord = feature_coord.zoomBy(-1).container()
-        for fetch, _ in fetcher.start(_wrap(coord)):
+        for fetch, _ in fetcher.fetch_tiles(_wrap(coord)):
             read_rows = fetch(10, coord_to_mercator_bounds(feature_coord))
         self.assertEquals(0, len(read_rows))
 
@@ -175,13 +175,13 @@ class TestQueryRawr(RawrTestCase):
         # 16, even though 16<20, because 16 is the "max zoom" at which all the
         # data is included.
         feature_coord = mercator_point_to_coord(16, shape.x, shape.y)
-        for fetcher, _ in fetch.start(_wrap(coord)):
+        for fetcher, _ in fetch.fetch_tiles(_wrap(coord)):
             read_rows = fetcher(16, coord_to_mercator_bounds(feature_coord))
         self.assertEquals(1, len(read_rows))
 
         # but it should not exist at zoom 15
         feature_coord = feature_coord.zoomBy(-1).container()
-        for fetcher, _ in fetch.start(_wrap(coord)):
+        for fetcher, _ in fetch.fetch_tiles(_wrap(coord)):
             read_rows = fetcher(10, coord_to_mercator_bounds(feature_coord))
         self.assertEquals(0, len(read_rows))
 
@@ -216,7 +216,7 @@ class TestQueryRawr(RawrTestCase):
                                layer_name='pois')
 
             feature_coord = mercator_point_to_coord(16, shape.x, shape.y)
-            for fetcher, _ in fetch.start(_wrap(coord)):
+            for fetcher, _ in fetch.fetch_tiles(_wrap(coord)):
                 read_rows = fetcher(16, coord_to_mercator_bounds(
                     feature_coord))
             self.assertEquals(1, len(read_rows))
@@ -285,7 +285,7 @@ class TestQueryRawr(RawrTestCase):
         # min zoom filter and geometry filter are okay.
         feature_coord = mercator_point_to_coord(
             feature_min_zoom, shape.x, shape.y)
-        for fetcher, _ in fetch.start(_wrap(coord)):
+        for fetcher, _ in fetch.fetch_tiles(_wrap(coord)):
             read_rows = fetcher(
                 feature_min_zoom, coord_to_mercator_bounds(feature_coord))
 
@@ -334,7 +334,7 @@ class TestLabelPlacement(RawrTestCase):
             min_zoom_fn, None, tables, tile_pyramid, layer_name=layer_name,
             label_placement_layers=label_placement_layers)
 
-        for fetcher, _ in fetch.start(_wrap(top_tile)):
+        for fetcher, _ in fetch.fetch_tiles(_wrap(top_tile)):
             read_rows = fetcher(tile.zoom, bounds)
         return read_rows
 
@@ -393,7 +393,7 @@ class TestGeometryClipping(RawrTestCase):
         fetch = self._make(
             min_zoom_fn, None, tables, tile_pyramid, layer_name=layer_name)
 
-        for fetcher, _ in fetch.start(_wrap(top_tile)):
+        for fetcher, _ in fetch.fetch_tiles(_wrap(top_tile)):
             read_rows = fetcher(tile.zoom, bounds)
         self.assertEqual(1, len(read_rows))
         return read_rows[0]
@@ -479,7 +479,7 @@ class TestNameHandling(RawrTestCase):
         fetch = make_rawr_data_fetcher(
             top_zoom, max_zoom, storage, layers, source)
 
-        for fetcher, _ in fetch.start(_wrap(top_tile)):
+        for fetcher, _ in fetch.fetch_tiles(_wrap(top_tile)):
             read_rows = fetcher(tile.zoom, coord_to_mercator_bounds(tile))
         # the RAWR query goes over features multiple times because of the
         # indexing, so we can't rely on all the properties for one feature to
@@ -581,7 +581,7 @@ class TestMeta(RawrTestCase):
         # min zoom filter and geometry filter are okay.
         feature_coord = mercator_point_to_coord(
             feature_min_zoom, shape.x, shape.y)
-        for fetcher, _ in fetch.start(_wrap(coord)):
+        for fetcher, _ in fetch.fetch_tiles(_wrap(coord)):
             read_rows = fetcher(
                 feature_min_zoom, coord_to_mercator_bounds(feature_coord))
 
@@ -650,7 +650,7 @@ class TestMeta(RawrTestCase):
         # min zoom filter and geometry filter are okay.
         feature_coord = mercator_point_to_coord(
             feature_min_zoom, *shape.coords[0])
-        for fetcher, _ in fetch.start(_wrap(coord)):
+        for fetcher, _ in fetch.fetch_tiles(_wrap(coord)):
             read_rows = fetcher(
                 feature_min_zoom, coord_to_mercator_bounds(feature_coord))
 

--- a/tests/test_query_split.py
+++ b/tests/test_query_split.py
@@ -3,7 +3,7 @@ import unittest
 
 class _NullFetcher(object):
 
-    def start(self, data):
+    def fetch_tiles(self, data):
         for datum in data:
             yield self, datum
 
@@ -27,7 +27,7 @@ class TestQuerySplit(unittest.TestCase):
         splitter = make_split_data_fetcher(10, above, below)
 
         all_data = [above_data, below_data]
-        result = splitter.start(all_data)
+        result = splitter.fetch_tiles(all_data)
         expected = [(above, above_data), (below, below_data)]
 
         # sadly, dicts aren't hashable and frozendict isn't a thing in the

--- a/tests/test_query_split.py
+++ b/tests/test_query_split.py
@@ -1,0 +1,38 @@
+import unittest
+
+
+class _NullFetcher(object):
+
+    def start(self, data):
+        for datum in data:
+            yield self, datum
+
+
+def _c(z, x, y):
+    from ModestMaps.Core import Coordinate
+    return Coordinate(zoom=z, column=x, row=y)
+
+
+class TestQuerySplit(unittest.TestCase):
+
+    def test_splits_jobs(self):
+        from tilequeue.query.split import make_split_data_fetcher
+
+        above = _NullFetcher()
+        below = _NullFetcher()
+
+        above_data = dict(coord=_c(9, 0, 0))
+        below_data = dict(coord=_c(10, 0, 0))
+
+        splitter = make_split_data_fetcher(10, above, below)
+
+        all_data = [above_data, below_data]
+        result = splitter.start(all_data)
+        expected = [(above, above_data), (below, below_data)]
+
+        # sadly, dicts aren't hashable and frozendict isn't a thing in the
+        # standard library, so seems easier to just sort the lists - although
+        # a defined sort order isn't available on these objects, they should
+        # be the same objects in memory, so even an id() based sorting should
+        # work.
+        self.assertEquals(sorted(expected), sorted(result))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,76 @@
+import unittest
+
+
+class TestCoordsByParent(unittest.TestCase):
+
+    def test_empty(self):
+        from tilequeue.utils import CoordsByParent
+
+        cbp = CoordsByParent(10)
+
+        count = 0
+        for key, coords in cbp:
+            count += 1
+
+        self.assertEquals(0, count)
+
+    def test_lower_zooms_not_grouped(self):
+        from tilequeue.utils import CoordsByParent
+        from ModestMaps.Core import Coordinate
+
+        cbp = CoordsByParent(10)
+
+        low_zoom_coords = [(9, 0, 0), (9, 0, 1), (9, 1, 0), (9, 1, 1)]
+        for z, x, y in low_zoom_coords:
+            coord = Coordinate(zoom=z, column=x, row=y)
+            cbp.add(coord)
+
+        count = 0
+        for key, coords in cbp:
+            self.assertEquals(1, len(coords))
+            count += 1
+
+        self.assertEquals(len(low_zoom_coords), count)
+
+    def test_higher_zooms_grouped(self):
+        from tilequeue.utils import CoordsByParent
+        from ModestMaps.Core import Coordinate
+
+        cbp = CoordsByParent(10)
+
+        def _c(z, x, y):
+            return Coordinate(zoom=z, column=x, row=y)
+
+        groups = {
+            _c(10, 0, 0): [_c(10, 0, 0), _c(11, 0, 0), _c(11, 0, 1)],
+            _c(10, 1, 1): [_c(11, 2, 2), _c(11, 3, 3), _c(12, 4, 4)],
+        }
+
+        for coords in groups.itervalues():
+            for coord in coords:
+                cbp.add(coord)
+
+        count = 0
+        for key, coords in cbp:
+            self.assertIn(key, groups)
+            self.assertEquals(set(groups[key]), set(coords))
+            count += 1
+
+        self.assertEquals(len(groups), count)
+
+    def test_with_extra_data(self):
+        from tilequeue.utils import CoordsByParent
+        from ModestMaps.Core import Coordinate
+
+        cbp = CoordsByParent(10)
+
+        coord = Coordinate(zoom=10, column=0, row=0)
+        cbp.add(coord, 'foo', 'bar')
+
+        count = 0
+        for key, coords in cbp:
+            self.assertEquals(1, len(coords))
+            self.assertEquals((coord, 'foo', 'bar'), coords[0])
+            count += 1
+
+        self.assertEquals(1, count)

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -549,6 +549,26 @@ def make_output_calc_mapping(process_yaml_cfg):
     return output_calc_mapping
 
 
+def make_min_zoom_calc_mapping(process_yaml_cfg):
+    # can't handle "callable" type - how do we get the min zoom fn?
+    assert process_yaml_cfg['type'] == 'parse'
+
+    min_zoom_calc_mapping = {}
+
+    parse_cfg = process_yaml_cfg['parse']
+    yaml_path = parse_cfg['path']
+    assert os.path.isdir(yaml_path), 'Invalid yaml path: %s' % yaml_path
+    from vectordatasource.meta.python import make_function_name_min_zoom
+    from vectordatasource.meta.python import output_min_zoom
+    from vectordatasource.meta.python import parse_layers
+    layer_parse_result = parse_layers(
+        yaml_path, output_min_zoom, make_function_name_min_zoom)
+    for layer_datum in layer_parse_result.layer_data:
+        min_zoom_calc_mapping[layer_datum.layer] = layer_datum.fn
+
+    return min_zoom_calc_mapping
+
+
 def tilequeue_process(cfg, peripherals):
     logger = make_logger(cfg, 'process')
     logger.warn('tilequeue processing started')

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -1455,7 +1455,8 @@ def tilequeue_process_tile(cfg, peripherals, args):
     data_fetcher = make_data_fetcher(cfg, layer_data, query_cfg, io_pool)
 
     unpadded_bounds = coord_to_mercator_bounds(coord)
-    source_rows = data_fetcher(coord.zoom, unpadded_bounds)
+    for fetch, _ in data_fetcher.start([dict(coord=coord)]):
+        source_rows = fetch(coord.zoom, unpadded_bounds)
     feature_layers = convert_source_data_to_feature_layers(
         source_rows, layer_data, unpadded_bounds, coord.zoom)
     cut_coords = []

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -608,7 +608,7 @@ def tilequeue_process(cfg, peripherals):
     n_max_io_workers = 50
     n_io_workers = min(n_total_needed, n_max_io_workers)
     io_pool = ThreadPool(n_io_workers)
-    feature_fetcher = make_data_fetcher(cfg, query_cfg, io_pool)
+    feature_fetcher = make_data_fetcher(cfg, layer_data, query_cfg, io_pool)
 
     # create all queues used to manage pipeline
 
@@ -1452,7 +1452,7 @@ def tilequeue_process_tile(cfg, peripherals, args):
     output_calc_mapping = make_output_calc_mapping(cfg.process_yaml_cfg)
     io_pool = ThreadPool(len(layer_data))
 
-    data_fetcher = make_data_fetcher(cfg, query_cfg, io_pool)
+    data_fetcher = make_data_fetcher(cfg, layer_data, query_cfg, io_pool)
 
     unpadded_bounds = coord_to_mercator_bounds(coord)
     source_rows = data_fetcher(coord.zoom, unpadded_bounds)

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -1475,7 +1475,7 @@ def tilequeue_process_tile(cfg, peripherals, args):
     data_fetcher = make_data_fetcher(cfg, layer_data, query_cfg, io_pool)
 
     unpadded_bounds = coord_to_mercator_bounds(coord)
-    for fetch, _ in data_fetcher.start([dict(coord=coord)]):
+    for fetch, _ in data_fetcher.fetch_tiles([dict(coord=coord)]):
         source_rows = fetch(coord.zoom, unpadded_bounds)
     feature_layers = convert_source_data_to_feature_layers(
         source_rows, layer_data, unpadded_bounds, coord.zoom)

--- a/tilequeue/metatile.py
+++ b/tilequeue/metatile.py
@@ -58,7 +58,7 @@ def make_multi_metatile(parent, tiles, date_time=None):
                  layer=layer)]
 
 
-def _common_parent(a, b):
+def common_parent(a, b):
     """
     Find the common parent tile of both a and b. The common parent is the tile
     at the highest zoom which both a and b can be transformed into by lowering
@@ -89,7 +89,7 @@ def _parent_tile(tiles):
             parent = t
 
         else:
-            parent = _common_parent(parent, t)
+            parent = common_parent(parent, t)
 
     return parent
 

--- a/tilequeue/query/__init__.py
+++ b/tilequeue/query/__init__.py
@@ -2,8 +2,15 @@ from tilequeue.query.fixture import make_fixture_data_fetcher
 from tilequeue.query.pool import DBConnectionPool
 from tilequeue.query.postgres import make_db_data_fetcher
 
+
 __all__ = [
     'DBConnectionPool',
     'make_db_data_fetcher',
     'make_fixture_data_fetcher',
 ]
+
+
+def make_data_fetcher(cfg, query_cfg, io_pool):
+    return make_db_data_fetcher(
+        cfg.postgresql_conn_info, cfg.template_path, cfg.reload_templates,
+        query_cfg, io_pool)

--- a/tilequeue/query/__init__.py
+++ b/tilequeue/query/__init__.py
@@ -1,16 +1,133 @@
 from tilequeue.query.fixture import make_fixture_data_fetcher
 from tilequeue.query.pool import DBConnectionPool
 from tilequeue.query.postgres import make_db_data_fetcher
+from tilequeue.query.rawr import make_rawr_data_fetcher
+from tilequeue.query.split import make_split_data_fetcher
 
 
 __all__ = [
     'DBConnectionPool',
     'make_db_data_fetcher',
     'make_fixture_data_fetcher',
+    'make_data_fetcher',
 ]
 
 
-def make_data_fetcher(cfg, query_cfg, io_pool):
-    return make_db_data_fetcher(
+def make_data_fetcher(cfg, layer_data, query_cfg, io_pool):
+    db_fetcher = make_db_data_fetcher(
         cfg.postgresql_conn_info, cfg.template_path, cfg.reload_templates,
         query_cfg, io_pool)
+
+    if cfg.yml.get('use-rawr-tiles'):
+        rawr_fetcher = _make_rawr_fetcher(
+            cfg, layer_data, query_cfg, io_pool)
+
+        group_by_zoom = cfg.yml.get('rawr').get('group-zoom')
+        assert group_by_zoom is not None, 'Missing group-zoom rawr config'
+        return make_split_data_fetcher(
+            group_by_zoom, db_fetcher, rawr_fetcher)
+
+    else:
+        return db_fetcher
+
+
+def _make_rawr_fetcher(cfg, layer_data, query_cfg, io_pool):
+    rawr_yaml = cfg.yml.get('rawr')
+    assert rawr_yaml is not None, 'Missing rawr configuration in yaml'
+
+    group_by_zoom = rawr_yaml.get('group-zoom')
+    assert group_by_zoom is not None, 'Missing group-zoom rawr config'
+
+    rawr_source_yaml = rawr_yaml.get('source')
+    assert rawr_source_yaml, 'Missing rawr source config'
+    bucket = rawr_source_yaml.get('bucket')
+    assert bucket, 'Missing rawr sink bucket'
+    prefix = rawr_source_yaml.get('prefix')
+    assert prefix, 'Missing rawr sink prefix'
+    suffix = rawr_source_yaml.get('suffix')
+    assert suffix, 'Missing rawr sink suffix'
+
+    import boto3
+    from tilequeue.rawr import RawrS3Source
+    s3_client = boto3.client('s3')
+    storage = RawrS3Source(s3_client, bucket, prefix, suffix, io_pool)
+
+    # TODO: this needs to be configurable, everywhere!
+    max_z = 16
+
+    # TODO: this is just wrong - need to refactor this per-"table"?
+    source = 'osm'
+
+    # TODO: put this in the config!
+    label_placement_layers = {
+        'point': set(['earth', 'water']),
+        'polygon': set(['buildings', 'earth', 'landuse', 'water']),
+        'linestring': set(['earth', 'landuse', 'water']),
+    }
+
+    layers = _make_layer_info(layer_data, cfg.process_yaml_cfg)
+
+    return make_rawr_data_fetcher(
+        group_by_zoom, max_z, storage, layers, source, label_placement_layers)
+
+
+def _make_layer_info(layer_data, process_yaml_cfg):
+    from tilequeue.query.common import LayerInfo
+
+    layers = {}
+    functions = _parse_yaml_functions(process_yaml_cfg)
+
+    for layer_datum in layer_data:
+        name = layer_datum['name']
+        min_zoom_fn, props_fn = functions[name]
+        shape_types = _parse_shape_types(layer_datum['geometry_types'])
+        layer_info = LayerInfo(min_zoom_fn, props_fn, shape_types)
+        layers[name] = layer_info
+
+    return layers
+
+
+def _parse_shape_types(inputs):
+    from tilequeue.query.common import shape_type_lookup
+
+    outputs = set()
+    for value in inputs:
+        outputs.add(shape_type_lookup(value))
+
+    if outputs:
+        return outputs
+    else:
+        return None
+
+
+def _parse_yaml_functions(process_yaml_cfg):
+    from vectordatasource.meta.python import make_function_name_props
+    from vectordatasource.meta.python import make_function_name_min_zoom
+    from vectordatasource.meta.python import output_kind
+    from vectordatasource.meta.python import output_min_zoom
+    from vectordatasource.meta.python import parse_layers
+    import os.path
+
+    # can't handle "callable" type - how do we get the min zoom fn?
+    assert process_yaml_cfg['type'] == 'parse'
+
+    parse_cfg = process_yaml_cfg['parse']
+    yaml_path = parse_cfg['path']
+
+    assert os.path.isdir(yaml_path)
+
+    output_layer_data = parse_layers(
+        yaml_path, output_kind, make_function_name_props)
+    min_zoom_layer_data = parse_layers(
+        yaml_path, output_min_zoom, make_function_name_min_zoom)
+
+    keys = set(output_layer_data.keys())
+    assert keys == set(min_zoom_layer_data.keys())
+
+    functions = {}
+    for key in keys:
+        min_zoom_fn = min_zoom_layer_data[key]
+        output_fn = output_layer_data[key]
+        functions[key] = (min_zoom_fn, output_fn)
+
+    return functions

--- a/tilequeue/query/common.py
+++ b/tilequeue/query/common.py
@@ -256,6 +256,11 @@ def mz_calculate_transit_routes_and_score(osm, node_id, way_id):
 def layer_properties(fid, shape, props, layer_name, zoom, osm):
     layer_props = props.copy()
 
+    # drop the 'source' tag, if it exists. we override it anyway, and it just
+    # gets confusing having multiple source tags. in the future, we may
+    # replace the whole thing with a separate 'meta' for source.
+    layer_props.pop('source', None)
+
     # need to make sure that the name is only applied to one of
     # the pois, landuse or buildings layers - in that order of
     # priority.

--- a/tilequeue/query/fixture.py
+++ b/tilequeue/query/fixture.py
@@ -133,11 +133,11 @@ class DataFetcher(object):
         self.label_placement_layers = label_placement_layers
         self.osm = OsmFixtureLookup(self.rows, self.rels)
 
-    @contextmanager
-    def start(self, top_coord):
+    def start(self, coords):
         # fixture data fetcher doesn't need this kind of session management,
         # so we can just return the same object for all uses.
-        yield self
+        for coord in coords:
+            yield self
 
     def __call__(self, zoom, unpadded_bounds):
         read_rows = []

--- a/tilequeue/query/fixture.py
+++ b/tilequeue/query/fixture.py
@@ -132,11 +132,11 @@ class DataFetcher(object):
         self.label_placement_layers = label_placement_layers
         self.osm = OsmFixtureLookup(self.rows, self.rels)
 
-    def start(self, coords):
+    def start(self, all_data):
         # fixture data fetcher doesn't need this kind of session management,
         # so we can just return the same object for all uses.
-        for coord in coords:
-            yield self
+        for data in all_data:
+            yield self, data
 
     def __call__(self, zoom, unpadded_bounds):
         read_rows = []

--- a/tilequeue/query/fixture.py
+++ b/tilequeue/query/fixture.py
@@ -7,7 +7,6 @@ from tilequeue.query.common import layer_properties
 from tilequeue.query.common import shape_type_lookup
 from tilequeue.query.common import mz_is_interesting_transit_relation
 from collections import defaultdict
-from contextlib import contextmanager
 
 
 class OsmFixtureLookup(object):

--- a/tilequeue/query/fixture.py
+++ b/tilequeue/query/fixture.py
@@ -7,6 +7,7 @@ from tilequeue.query.common import layer_properties
 from tilequeue.query.common import shape_type_lookup
 from tilequeue.query.common import mz_is_interesting_transit_relation
 from collections import defaultdict
+from contextlib import contextmanager
 
 
 class OsmFixtureLookup(object):
@@ -131,6 +132,12 @@ class DataFetcher(object):
         self.rels = rels
         self.label_placement_layers = label_placement_layers
         self.osm = OsmFixtureLookup(self.rows, self.rels)
+
+    @contextmanager
+    def start(self, top_coord):
+        # fixture data fetcher doesn't need this kind of session management,
+        # so we can just return the same object for all uses.
+        yield self
 
     def __call__(self, zoom, unpadded_bounds):
         read_rows = []

--- a/tilequeue/query/fixture.py
+++ b/tilequeue/query/fixture.py
@@ -132,7 +132,7 @@ class DataFetcher(object):
         self.label_placement_layers = label_placement_layers
         self.osm = OsmFixtureLookup(self.rows, self.rels)
 
-    def start(self, all_data):
+    def fetch_tiles(self, all_data):
         # fixture data fetcher doesn't need this kind of session management,
         # so we can just return the same object for all uses.
         for data in all_data:

--- a/tilequeue/query/postgres.py
+++ b/tilequeue/query/postgres.py
@@ -169,11 +169,11 @@ class DataFetcher(object):
         self.sql_conn_pool = DBConnectionPool(
             self.dbnames, self.conn_info)
 
-    @contextmanager
-    def start(self, top_coord):
+    def start(self, coords):
         # postgres data fetcher doesn't need this kind of session management,
         # so we can just return the same object for all uses.
-        yield self
+        for coord in coords:
+            yield self
 
     def __call__(self, zoom, unpadded_bounds):
         queries = self.queries_generator(zoom, unpadded_bounds)

--- a/tilequeue/query/postgres.py
+++ b/tilequeue/query/postgres.py
@@ -1,5 +1,4 @@
 from collections import namedtuple
-from contextlib import contextmanager
 from jinja2 import Environment
 from jinja2 import FileSystemLoader
 from psycopg2.extras import RealDictCursor

--- a/tilequeue/query/postgres.py
+++ b/tilequeue/query/postgres.py
@@ -168,11 +168,11 @@ class DataFetcher(object):
         self.sql_conn_pool = DBConnectionPool(
             self.dbnames, self.conn_info)
 
-    def start(self, coords):
+    def start(self, all_data):
         # postgres data fetcher doesn't need this kind of session management,
         # so we can just return the same object for all uses.
-        for coord in coords:
-            yield self
+        for data in all_data:
+            yield self, data
 
     def __call__(self, zoom, unpadded_bounds):
         queries = self.queries_generator(zoom, unpadded_bounds)

--- a/tilequeue/query/postgres.py
+++ b/tilequeue/query/postgres.py
@@ -168,7 +168,7 @@ class DataFetcher(object):
         self.sql_conn_pool = DBConnectionPool(
             self.dbnames, self.conn_info)
 
-    def start(self, all_data):
+    def fetch_tiles(self, all_data):
         # postgres data fetcher doesn't need this kind of session management,
         # so we can just return the same object for all uses.
         for data in all_data:

--- a/tilequeue/query/postgres.py
+++ b/tilequeue/query/postgres.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from contextlib import contextmanager
 from jinja2 import Environment
 from jinja2 import FileSystemLoader
 from psycopg2.extras import RealDictCursor
@@ -167,6 +168,12 @@ class DataFetcher(object):
         self.dbnames_query_index = 0
         self.sql_conn_pool = DBConnectionPool(
             self.dbnames, self.conn_info)
+
+    @contextmanager
+    def start(self, top_coord):
+        # postgres data fetcher doesn't need this kind of session management,
+        # so we can just return the same object for all uses.
+        yield self
 
     def __call__(self, zoom, unpadded_bounds):
         queries = self.queries_generator(zoom, unpadded_bounds)

--- a/tilequeue/query/rawr.py
+++ b/tilequeue/query/rawr.py
@@ -573,12 +573,13 @@ class DataFetcher(object):
         self.source = source
         self.label_placement_layers = label_placement_layers
 
-    def start(self, coords):
+    def start(self, all_data):
         # group all coords by the "unit of work" zoom, i.e: z10 for
         # RAWR tiles.
         coords_by_parent = CoordsByParent(self.min_z)
-        for coord in coords:
-            coords_by_parent.add(coord)
+        for data in all_data:
+            coord = data['coord']
+            coords_by_parent.add(coord, data)
 
         # this means we can dispatch groups of jobs by their common parent
         # tile, which allows DataFetcher to take advantage of any common
@@ -592,8 +593,8 @@ class DataFetcher(object):
                 fetcher = RawrTile(self.layers, tables, tile_pyramid,
                                    self.label_placement_layers, self.source)
 
-                for coord in coord_group:
-                    yield fetcher
+                for coord, data in coord_group:
+                    yield fetcher, data
 
 
 # Make a RAWR tile data fetcher given:

--- a/tilequeue/query/rawr.py
+++ b/tilequeue/query/rawr.py
@@ -596,8 +596,20 @@ class DataFetcher(object):
                     yield fetcher
 
 
-# tables is a callable which should return a generator over the rows of the
-# table when called with the table name.
+# Make a RAWR tile data fetcher given:
+#
+#  - min_z:   Lowest *nominal* zoom level, e.g: z10 for a RAWR tile.
+#  - max_z:   Highest *nominal* zoom level, e.g: z16 for a RAWR tile.
+#  - storage: Callable which takes a TilePyramid as the only argument,
+#             returning a "tables" callable. The "tables" callable returns a
+#             list of rows given the table name as its only argument.
+#  - layers:  A dict of layer name to LayerInfo (see fixture.py).
+#  - source:  String indicating the source of the data (e.g: 'osm').
+#  - label_placement_layers:
+#             A dict of geometry type ('point', 'linestring', 'polygon') to
+#             set (or other in-supporting collection) of layer names.
+#             Geometries of that type in that layer will have a label
+#             placement generated for them.
 def make_rawr_data_fetcher(min_z, max_z, storage, layers, source,
                            label_placement_layers={}):
     return DataFetcher(min_z, max_z, storage, layers, source,

--- a/tilequeue/query/rawr.py
+++ b/tilequeue/query/rawr.py
@@ -591,7 +591,7 @@ class DataFetcher(object):
         self.source = source
         self.label_placement_layers = label_placement_layers
 
-    def start(self, all_data):
+    def fetch_tiles(self, all_data):
         # group all coords by the "unit of work" zoom, i.e: z10 for
         # RAWR tiles.
         coords_by_parent = CoordsByParent(self.min_z)

--- a/tilequeue/query/split.py
+++ b/tilequeue/query/split.py
@@ -16,7 +16,7 @@ class DataFetcher(object):
         self.below_fetcher = below_fetcher
         self.above_fetcher = above_fetcher
 
-    def start(self, all_data):
+    def fetch_tiles(self, all_data):
         below_data = []
         above_data = []
 
@@ -27,8 +27,8 @@ class DataFetcher(object):
             else:
                 above_data.append(data)
 
-        return chain(self.above_fetcher.start(above_data),
-                     self.below_fetcher.start(below_data))
+        return chain(self.above_fetcher.fetch_tiles(above_data),
+                     self.below_fetcher.fetch_tiles(below_data))
 
 
 def make_split_data_fetcher(split_zoom, below_fetcher, above_fetcher):

--- a/tilequeue/query/split.py
+++ b/tilequeue/query/split.py
@@ -1,0 +1,35 @@
+from itertools import chain
+
+
+class DataFetcher(object):
+
+    """
+    Splits requests between two data fetchers depending on whether the zoom of
+    the coordinate is above or below (or equal) the "split zoom".
+
+    This is used to choose between going to the database for low zooms or
+    fetching a RAWR tile for high zooms.
+    """
+
+    def __init__(self, split_zoom, below_fetcher, above_fetcher):
+        self.split_zoom = split_zoom
+        self.below_fetcher = below_fetcher
+        self.above_fetcher = above_fetcher
+
+    def start(self, all_data):
+        below_data = []
+        above_data = []
+
+        for data in all_data:
+            coord = data['coord']
+            if coord.zoom < self.split_zoom:
+                below_data.append(data)
+            else:
+                above_data.append(data)
+
+        return chain(self.above_fetcher.start(above_data),
+                     self.below_fetcher.start(below_data))
+
+
+def make_split_data_fetcher(split_zoom, below_fetcher, above_fetcher):
+    return DataFetcher(split_zoom, below_fetcher, above_fetcher)

--- a/tilequeue/rawr.py
+++ b/tilequeue/rawr.py
@@ -311,9 +311,10 @@ def make_rawr_zip_payload(rawr_tile, date_time=None):
 
 def unpack_rawr_zip_payload(io):
     """unpack a zipfile and turn it into a callable "tables" object."""
-    # TODO: the io we get from S3 is streaming, so we can't seek on it, but
-    # zipfile seems to require that. should we write a temporary file rather
-    # than storing it all in memory?
+    # the io we get from S3 is streaming, so we can't seek on it, but zipfile
+    # seems to require that. so we buffer it all in memory. RAWR tiles are
+    # generally up to around 100MB in size, which should be safe to store in
+    # RAM.
     buf = io.BytesIO(io.read())
     zfh = zipfile.ZipFile(buf, 'r')
 
@@ -359,36 +360,55 @@ class RawrS3Sink(object):
         )
 
 
+# implement the "get_table" interface, but always return an empty list. this
+# allows us to fake an empty tile that might not be backed by any real data.
+def _empty_table(table_name):
+    return []
+
+
 class RawrS3Source(object):
 
     """Rawr source to read from S3. Uses a thread pool for I/O if provided."""
 
-    def __init__(self, s3_client, bucket, prefix, suffix, io_pool=None):
+    def __init__(self, s3_client, bucket, prefix, suffix, io_pool=None,
+                 allow_missing_tiles=False):
         self.s3_client = s3_client
         self.bucket = bucket
         self.prefix = prefix
         self.suffix = suffix
         self.io_pool = io_pool
+        self.allow_missing_tiles = allow_missing_tiles
 
     def _get_object(self, tile):
         location = make_rawr_s3_path(tile, self.prefix, self.suffix)
 
-        response = self.s3_client.get_object(
+        try:
+            response = self.s3_client.get_object(
                 Bucket=self.bucket,
                 Key=location,
-        )
+            )
+        except Exception, e:
+            # if we allow missing tiles, then translate a 404 exception into a
+            # value response. this is useful for local or dev environments
+            # where we might not have a global build, but don't want the lack
+            # of RAWR tiles to kill jobs.
+            if self.allow_missing_tiles and isinstance(e, ClientError):
+                if e.response['ResponseMetadata']['HTTPStatusCode'] == 404:
+                    return None
+            raise
 
         return response
 
     def __call__(self, tile):
-        # TODO: i guess this throws an exception if the object is missing, or
-        # there's a server error. do we want to catch it, or is propagating it
-        # the right option?
+        # throws an exception if the object is missing - RAWR tiles
         if self.io_pool:
             response = self.thread_pool.apply(
                 self._get_object, (tile,))
         else:
             response = self._get_object(tile)
+
+        if response is None:
+            return _empty_table
 
         # check that the response isn't a delete marker.
         assert not response['DeleteMarker']

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -1,5 +1,6 @@
 from itertools import izip
 from operator import attrgetter
+from ModestMaps.Core import Coordinate
 from psycopg2.extensions import TransactionRollbackError
 from tilequeue.process import convert_source_data_to_feature_layers
 from tilequeue.process import process_coord

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -227,11 +227,9 @@ class DataFetch(object):
                 saw_sentinel = True
                 break
 
-            coords = [data['coord'] for data in all_data]
-            metadatas = [data['metadata'] for data in all_data]
-            fetches = self.fetcher.start(coords)
-
-            for fetch, coord, metadata in izip(fetches, coords, metadatas):
+            for fetch, data in self.fetcher.start(all_data):
+                metadata = data['metadata']
+                coord = data['coord']
                 if self._fetch_and_output(fetch, coord, metadata, output):
                     break
 

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -227,7 +227,7 @@ class DataFetch(object):
                 saw_sentinel = True
                 break
 
-            for fetch, data in self.fetcher.start(all_data):
+            for fetch, data in self.fetcher.fetch_tiles(all_data):
                 metadata = data['metadata']
                 coord = data['coord']
                 if self._fetch_and_output(fetch, coord, metadata, output):


### PR DESCRIPTION
Added the ability to load RAWR tiles for processing from S3, or generate them directly from the database. The latter is useful for testing, and bypasses the round-trip via the msgpack-encoded `.zip` file, but is otherwise identical (and takes a while).

Added a `DataFetcher` implementation which is able to dynamically switch between database and RAWR tiles based on the zoom level(s) of the incoming tiles.

Plenty of TODOs in here to follow up, but hopefully this is a "save point" and we can clear the TODOs up afterwards.