### PR TITLE
Add json logging to tilequeue processing

### DIFF
--- a/logging.conf.sample
+++ b/logging.conf.sample
@@ -2,10 +2,10 @@
 keys=root,process,seed,prune_tiles_of_interest,enqueue_tiles_of_interest,dump_tiles_of_interest,load_tiles_of_interest,wof_process_neighbourhoods,query,consume_tile_traffic,tile_status,stuck_tiles,delete_stuck_tiles,rawr_enqueue,rawr_process
 
 [handlers]
-keys=consoleHandler
+keys=consoleHandler,jsonConsoleHandler
 
 [formatters]
-keys=simpleFormatter
+keys=simpleFormatter,jsonFormatter
 
 [logger_root]
 level=WARNING
@@ -37,7 +37,7 @@ propagate=0
 
 [logger_process]
 level=INFO
-handlers=consoleHandler
+handlers=jsonConsoleHandler
 qualName=process
 propagate=0
 
@@ -99,6 +99,15 @@ propagate=0
 class=StreamHandler
 formatter=simpleFormatter
 args=(sys.stdout,)
+
+[handler_jsonConsoleHandler]
+class=StreamHandler
+formatter=jsonFormatter
+args=(sys.stdout,)
+
+[formatter_jsonFormatter]
+format=%(asctime)s %(message)s
+datefmt=%Y-%m-%dT%H:%M:%S%z
 
 [formatter_simpleFormatter]
 format=%(asctime)s - %(name)s - %(levelname)s - %(message)s

--- a/tilequeue/log.py
+++ b/tilequeue/log.py
@@ -31,10 +31,7 @@ def log_level_name(log_level):
 
 
 def log_category_name(log_category):
-    if log_category == LogCategory.QUEUE_SIZES:
-        return 'queue-sizes'
-    else:
-        return log_category.name.lower()
+    return log_category.name.lower()
 
 
 class JsonTileProcessingLogger(object):

--- a/tilequeue/log.py
+++ b/tilequeue/log.py
@@ -1,0 +1,111 @@
+from enum import Enum
+import json
+import logging
+import sys
+
+
+def make_coord_dict(coord):
+    """helper function to make a dict from a coordinate for logging"""
+    return dict(
+        z=coord.zoom,
+        x=coord.column,
+        y=coord.row,
+    )
+
+
+class LogLevel(Enum):
+    DEBUG = logging.DEBUG
+    INFO = logging.INFO
+    WARNING = logging.WARNING
+    ERROR = logging.ERROR
+
+
+class LogCategory(Enum):
+    PROCESS = 1
+    LIFECYCLE = 2
+    QUEUE_SIZES = 3
+
+
+def log_level_name(log_level):
+    return log_level.name.lower()
+
+
+def log_category_name(log_category):
+    if log_category == LogCategory.QUEUE_SIZES:
+        return 'queue-sizes'
+    else:
+        return log_category.name.lower()
+
+
+class JsonTileProcessingLogger(object):
+
+    def __init__(self, logger):
+        self.logger = logger
+
+    def log(self, log_level, log_category, msg, exception,
+            formatted_stacktrace, coord):
+        try:
+            log_level_str = log_level_name(log_level)
+            logging_log_level = log_level.value
+        except:
+            print >>sys.stderr, ('ERROR: code error: invalid log level: %s' %
+                                 log_level)
+            log_level_str = log_level_name(LogLevel.ERROR)
+            logging_log_level = logging.ERROR
+        try:
+            log_category_str = log_category_name(log_category)
+        except:
+            print >>sys.stderr, ('ERROR: code error: invalid log category: %s'
+                                 % log_category)
+            log_category_str = log_category_name(LogCategory.PROCESS)
+
+        json_obj = dict(
+            category=log_category_str,
+            type=log_level_str,
+            msg=msg,
+        )
+        if exception:
+            json_obj['exception'] = str(exception)
+        if formatted_stacktrace:
+            json_obj['stacktrace'] = formatted_stacktrace,
+        if coord:
+            json_obj['coord'] = make_coord_dict(coord)
+        json_str = json.dumps(json_obj)
+        self.logger.log(logging_log_level, json_str)
+
+    def error(self, msg, exception, formatted_stacktrace, coord=None):
+        self.log(LogLevel.ERROR, LogCategory.PROCESS, msg, exception,
+                 formatted_stacktrace, coord)
+
+    def log_processed_coord(self, coord_proc_data):
+        json_obj = dict(
+            category=log_category_name(LogCategory.PROCESS),
+            type=log_level_name(LogLevel.INFO),
+            coord=make_coord_dict(coord_proc_data.coord),
+            timing=coord_proc_data.timing,
+            size=coord_proc_data.size,
+            storage=coord_proc_data.store_info,
+        )
+        json_str = json.dumps(json_obj)
+        self.logger.info(json_str)
+
+    def lifecycle(self, msg):
+        self.log(
+            LogLevel.INFO, LogCategory.LIFECYCLE, msg, None, None, None)
+
+    def log_queue_sizes(self, queue_info):
+        sizes = {}
+        for queue, queue_name in queue_info:
+            size = dict(size=queue.qsize())
+            if queue.empty():
+                size['empty'] = True
+            if queue.full():
+                size['full'] = True
+            sizes[queue_name] = size
+        json_obj = dict(
+            category=log_category_name(LogCategory.QUEUE_SIZES),
+            type=log_level_name(LogLevel.INFO),
+            sizes=sizes,
+        )
+        json_str = json.dumps(json_obj)
+        self.logger.info(json_str)

--- a/tilequeue/log.py
+++ b/tilequeue/log.py
@@ -45,15 +45,15 @@ class JsonTileProcessingLogger(object):
             log_level_str = log_level_name(log_level)
             logging_log_level = log_level.value
         except:
-            print >>sys.stderr, ('ERROR: code error: invalid log level: %s' %
-                                 log_level)
+            sys.stderr.write('ERROR: code error: invalid log level: %s\n' %
+                             log_level)
             log_level_str = log_level_name(LogLevel.ERROR)
             logging_log_level = logging.ERROR
         try:
             log_category_str = log_category_name(log_category)
         except:
-            print >>sys.stderr, ('ERROR: code error: invalid log category: %s'
-                                 % log_category)
+            sys.stderr.write('ERROR: code error: invalid log category: %s\n' %
+                             log_category)
             log_category_str = log_category_name(LogCategory.PROCESS)
 
         json_obj = dict(

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -541,7 +541,6 @@ class TileQueueWriter(object):
 
             layers = metadata['layers']
             size = layers['size']
-            # size_as_str = repr(size)
 
             store_info = metadata['store']
 


### PR DESCRIPTION
Connects to https://github.com/mapzen/tile-tasks/issues/268

A new logging abstraction was created, and the processing worker classes now all use it for logging.

I expect this to conflict with https://github.com/tilezen/tilequeue/pull/255. I'm happy to resolve any conflicts once that gets merged, since the changes I've made are all just logging based and will not have changed any of the logic.