### PR TITLE
Add rawr-seed-toi command

### DIFF
--- a/logging.conf.sample
+++ b/logging.conf.sample
@@ -1,5 +1,5 @@
 [loggers]
-keys=root,process,seed,prune_tiles_of_interest,enqueue_tiles_of_interest,dump_tiles_of_interest,load_tiles_of_interest,wof_process_neighbourhoods,query,consume_tile_traffic,tile_status,stuck_tiles,delete_stuck_tiles,rawr_enqueue,rawr_process
+keys=root,process,seed,prune_tiles_of_interest,enqueue_tiles_of_interest,dump_tiles_of_interest,load_tiles_of_interest,wof_process_neighbourhoods,query,consume_tile_traffic,tile_status,stuck_tiles,delete_stuck_tiles,rawr_enqueue,rawr_process,rawr_seed
 
 [handlers]
 keys=consoleHandler,jsonConsoleHandler
@@ -93,6 +93,12 @@ propagate=0
 level=INFO
 handlers=consoleHandler
 qualName=rawr_process
+propagate=0
+
+[logger_rawr_seed]
+level=INFO
+handlers=consoleHandler
+qualName=rawr_seed
 propagate=0
 
 [handler_consoleHandler]

--- a/tilequeue/rawr.py
+++ b/tilequeue/rawr.py
@@ -120,7 +120,7 @@ class RawrEnqueuer(object):
 
         if self.logger:
             self.logger.info(
-                'Expiry processed: '
+                'Rawr tiles enqueued: '
                 'coords(%d) payloads(%d) enqueue-calls(%d))' %
                 (n_coords, n_payloads, n_msgs_sent))
 


### PR DESCRIPTION
Connects to https://github.com/mapzen/tile-tasks/issues/290

This command will effectively replace the other seed command for our purposes. Higher zoom level tiles will get enqueued onto the rawr queue that need to get grouped, and after the rawr tile gets generated, the children tiles of that rawr tile will get enqeueud for processing. Low zoom level tiles will get enqueued directly to the tilequeue processing queues.

If we wanted to split this apart a little bit more in the future, we'd need to have the consumers know that these tiles enqueued for processing are for rawr tile generation only, and not for subsequent tilequeue processing, as is the typical workflow after applying diffs.