### PR TITLE
Add region to boto3 sqs/s3 clients

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -263,7 +263,9 @@ toi-prune:
 rawr:
   # this is the parent zoom level that coordinates are expected to be grouped under
   group-zoom: 10
-  queue: <sqs-queue-name>
+  queue:
+    name: <sqs-queue-name>
+    region: us-east-1
   postgresql:
     host: localhost
     port: 5432
@@ -272,5 +274,6 @@ rawr:
     password: dbpassword
   sink:
     bucket: s3-bucket-name
+    region: us-east-1
     prefix: s3-bucket-prefix
     suffix: .zip


### PR DESCRIPTION
Connects to https://github.com/mapzen/tile-tasks/issues/290

Without the region, creating the client fails on ec2 instances. Locally this works for me because I have a default region set up in my .aws/config.

I could have most likely also fixed this by setting an environment variable on the command, but I think having it in the tilequeue config file is nice because it's all in the same place that way.