### PR TITLE
Fix some RAWR-related TODOs

### DIFF
--- a/tests/test_query_fixture.py
+++ b/tests/test_query_fixture.py
@@ -311,7 +311,7 @@ class TestNameHandling(FixtureTestCase):
             return {}
 
         shape = Point(0, 0)
-        props = {'name': 'Foo'}
+        props = {'name': 'Foo', 'name:en': 'Bar'}
 
         rows = [
             (1, shape, props),
@@ -326,17 +326,24 @@ class TestNameHandling(FixtureTestCase):
         read_rows = fetch(16, coord_to_mercator_bounds(feature_coord))
         self.assertEqual(1, len(read_rows))
 
-        all_names = set(expected_layer_names) | set(input_layer_names)
-        for name in all_names:
-            properties_name = '__%s_properties__' % name
+        all_layer_names = set(expected_layer_names) | set(input_layer_names)
+        for layer_name in all_layer_names:
+            properties_name = '__%s_properties__' % layer_name
             self.assertTrue(properties_name in read_rows[0])
-            actual_name = read_rows[0][properties_name].get('name')
-            if name in expected_layer_names:
-                expected_name = props.get('name')
-                self.assertEquals(expected_name, actual_name)
-            else:
-                # check the name doesn't appear anywhere else
-                self.assertEquals(None, actual_name)
+            for key in props.keys():
+                actual_name = read_rows[0][properties_name].get(key)
+                if layer_name in expected_layer_names:
+                    expected_name = props.get(key)
+                    self.assertEquals(
+                        expected_name, actual_name,
+                        msg=('expected=%r, actual=%r for key=%r'
+                             % (expected_name, actual_name, key)))
+                else:
+                    # check the name doesn't appear anywhere else
+                    self.assertEquals(
+                        None, actual_name,
+                        msg=('got actual=%r for key=%r, expected no value'
+                             % (actual_name, key)))
 
     def test_name_single_layer(self):
         # in any oone of the pois, landuse or buildings layers, a name

--- a/tests/test_query_rawr.py
+++ b/tests/test_query_rawr.py
@@ -460,7 +460,7 @@ class TestNameHandling(RawrTestCase):
             return {}
 
         shape = Point(0, 0)
-        props = {'name': 'Foo'}
+        props = {'name': 'Foo', 'name:en': 'Bar'}
 
         tables = TestGetTable({
             'planet_osm_point': [
@@ -495,17 +495,24 @@ class TestNameHandling(RawrTestCase):
                     self.assertFalse(key in all_props)
                     all_props[key] = val
 
-        all_names = set(expected_layer_names) | set(input_layer_names)
-        for name in all_names:
-            properties_name = '__%s_properties__' % name
+        all_layer_names = set(expected_layer_names) | set(input_layer_names)
+        for layer_name in all_layer_names:
+            properties_name = '__%s_properties__' % layer_name
             self.assertTrue(properties_name in all_props)
-            actual_name = all_props[properties_name].get('name')
-            if name in expected_layer_names:
-                expected_name = props.get('name')
-                self.assertEquals(expected_name, actual_name)
-            else:
-                # check the name doesn't appear anywhere else
-                self.assertEquals(None, actual_name)
+            for key in props.keys():
+                actual_name = all_props[properties_name].get(key)
+                if layer_name in expected_layer_names:
+                    expected_name = props.get(key)
+                    self.assertEquals(
+                        expected_name, actual_name,
+                        msg=('expected=%r, actual=%r for key=%r'
+                             % (expected_name, actual_name, key)))
+                else:
+                    # check the name doesn't appear anywhere else
+                    self.assertEquals(
+                        None, actual_name,
+                        msg=('got actual=%r for key=%r, expected no value'
+                             % (actual_name, key)))
 
     def test_name_single_layer(self):
         # in any oone of the pois, landuse or buildings layers, a name

--- a/tests/test_query_rawr.py
+++ b/tests/test_query_rawr.py
@@ -8,11 +8,17 @@ class TestGetTable(object):
     previously set up in the test.
     """
 
-    def __init__(self, tables):
+    def __init__(self, tables, source='test'):
+        from tilequeue.process import lookup_source, Source
         self.tables = tables
+        # first look up source, in case it's a real one that we're testing.
+        # if not, then set it to a test value
+        self.source = lookup_source(source) or Source(source, source)
+        assert isinstance(self.source, Source)
 
     def __call__(self, table_name):
-        return self.tables.get(table_name, [])
+        from tilequeue.query.common import Table
+        return Table(self.source, self.tables.get(table_name, []))
 
 
 class ConstantStorage(object):
@@ -32,14 +38,14 @@ class RawrTestCase(unittest.TestCase):
 
     def _make(self, min_zoom_fn, props_fn, tables, tile_pyramid,
               layer_name='testlayer', label_placement_layers={},
-              source='test', min_z=10, max_z=16):
+              min_z=10, max_z=16):
         from tilequeue.query.common import LayerInfo
         from tilequeue.query.rawr import make_rawr_data_fetcher
 
         layers = {layer_name: LayerInfo(min_zoom_fn, props_fn)}
         storage = ConstantStorage(tables)
         return make_rawr_data_fetcher(
-            min_z, max_z, storage, layers, source,
+            min_z, max_z, storage, layers,
             label_placement_layers=label_placement_layers)
 
 
@@ -271,15 +277,14 @@ class TestQueryRawr(RawrTestCase):
         tables = TestGetTable({
             'planet_osm_point': [(0, shape.wkb,
                                   {'source': 'originalrowsource'})],
-        })
+        }, source='testingquerysource')
 
         zoom = 10
         max_zoom = zoom + 5
         coord = mercator_point_to_coord(zoom, shape.x, shape.y)
         tile_pyramid = TilePyramid(zoom, coord.column, coord.row, max_zoom)
 
-        fetch = self._make(min_zoom_fn, None, tables, tile_pyramid,
-                           source='testingquerysource')
+        fetch = self._make(min_zoom_fn, None, tables, tile_pyramid)
 
         # first, check that it can get the original item back when both the
         # min zoom filter and geometry filter are okay.
@@ -462,11 +467,12 @@ class TestNameHandling(RawrTestCase):
         shape = Point(0, 0)
         props = {'name': 'Foo', 'name:en': 'Bar'}
 
+        source = 'test'
         tables = TestGetTable({
             'planet_osm_point': [
                 (1, shape.wkb, props),
             ],
-        })
+        }, source)
 
         tile = mercator_point_to_coord(max_zoom, shape.x, shape.y)
         top_tile = tile.zoomTo(top_zoom).container()
@@ -474,10 +480,9 @@ class TestNameHandling(RawrTestCase):
         layers = {}
         for name in input_layer_names:
             layers[name] = LayerInfo(min_zoom_fn, props_fn)
-        source = 'test'
         storage = ConstantStorage(tables)
         fetch = make_rawr_data_fetcher(
-            top_zoom, max_zoom, storage, layers, source)
+            top_zoom, max_zoom, storage, layers)
 
         for fetcher, _ in fetch.fetch_tiles(_wrap(top_tile)):
             read_rows = fetcher(tile.zoom, coord_to_mercator_bounds(tile))

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -215,20 +215,34 @@ def _accumulate_props(dest_props, src_props):
 Metadata = namedtuple('Metadata', 'source')
 
 
+# source ties together a short name for a source of data and a longer tag
+# value to use on features from that source.
+#
+# note that this isn't an Enum, since we want sources to be extended for
+# testing and 3rd party re-use with additional data sources.
+#
+# for example:
+#   osm = Source('osm', 'openstreetmap.org'),
+#   wof = Source('wof', 'whosonfirst.mapzen.com'),
+Source = namedtuple('Source', 'name value')
+
+
 def make_metadata(source):
-    return Metadata(source)
+    assert source is None or isinstance(source, Source)
+    return Metadata(source and source.name)
 
 
 def lookup_source(source):
     result = None
     if source == 'openstreetmap.org':
-        result = 'osm'
+        result = Source('osm', source)
     elif source == 'naturalearthdata.com':
-        result = 'ne'
+        result = Source('ne', source)
     elif source == 'openstreetmapdata.com':
-        result = 'shp'
+        result = Source('shp', source)
     elif source == 'whosonfirst.mapzen.com':
-        result = 'wof'
+        result = Source('wof', source)
+
     return result
 
 

--- a/tilequeue/query/common.py
+++ b/tilequeue/query/common.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 from collections import defaultdict
 from itertools import izip
+from tilequeue.process import Source
 
 
 def namedtuple_with_defaults(name, props, defaults):
@@ -41,7 +42,18 @@ def deassoc(x):
 # fixtures extend metadata to include ways and relations for the feature.
 # this is unnecessary for SQL, as the ways and relations tables are
 # "ambiently available" and do not need to be passed in arguments.
-Metadata = namedtuple('Metadata', 'source ways relations')
+class Metadata(object):
+    def __init__(self, source, ways, relations):
+        assert source is None or isinstance(source, Source)
+        self.source = source and source.name
+        self.ways = ways
+        self.relations = relations
+
+
+class Table(namedtuple('Table', 'source rows')):
+    def __init__(self, source, rows):
+        super(Table, self).__init__(source, rows)
+        assert isinstance(source, Source)
 
 
 def shape_type_lookup(shape):

--- a/tilequeue/query/fixture.py
+++ b/tilequeue/query/fixture.py
@@ -6,6 +6,7 @@ from tilequeue.query.common import Relation
 from tilequeue.query.common import layer_properties
 from tilequeue.query.common import shape_type_lookup
 from tilequeue.query.common import mz_is_interesting_transit_relation
+from tilequeue.query.common import name_keys
 from collections import defaultdict
 
 
@@ -228,12 +229,14 @@ class DataFetcher(object):
 
                 # add back name into whichever of the pois, landuse or
                 # buildings layers has claimed this feature.
-                name = props.get('name', None)
-                if name:
+                names = {}
+                for k in name_keys(props):
+                    names[k] = props[k]
+                if names:
                     for layer_name in ('pois', 'landuse', 'buildings'):
                         props_name = '__%s_properties__' % layer_name
                         if props_name in read_row:
-                            read_row[props_name]['name'] = name
+                            read_row[props_name].update(names)
                             break
 
                 read_row['__id__'] = fid

--- a/tilequeue/query/rawr.py
+++ b/tilequeue/query/rawr.py
@@ -7,6 +7,7 @@ from tilequeue.query.common import is_station_or_line
 from tilequeue.query.common import deassoc
 from tilequeue.query.common import mz_is_interesting_transit_relation
 from tilequeue.query.common import shape_type_lookup
+from tilequeue.query.common import name_keys
 from tilequeue.transform import calculate_padded_bounds
 from tilequeue.utils import CoordsByParent
 from raw_tiles.tile import shape_tile_coverage
@@ -525,9 +526,11 @@ class RawrTile(object):
             read_row = {}
             generate_label_placement = False
 
-            # add name into whichever of the pois, landuse or buildings
+            # add names into whichever of the pois, landuse or buildings
             # layers has claimed this feature.
-            name = props.get('name', None)
+            names = {}
+            for k in name_keys(props):
+                names[k] = props[k]
             named_layer = self._named_layer(layer_min_zooms)
 
             for layer_name, min_zoom in layer_min_zooms.items():
@@ -542,8 +545,8 @@ class RawrTile(object):
                     fid, shape, props, layer_name, zoom, self.osm)
                 layer_props['min_zoom'] = min_zoom
 
-                if name and named_layer == layer_name:
-                    layer_props['name'] = name
+                if names and named_layer == layer_name:
+                    layer_props.update(names)
 
                 read_row['__' + layer_name + '_properties__'] = layer_props
 


### PR DESCRIPTION
* Add support for stations being multipolygon relations (already had support for nodes and ways).
* When assigning names to one of `pois`, `landuse`, `buildings`, assign all name variants and translations, not just `name` itself.
* Remove the hard-coded OSM "source" from RAWR, and make it something that is provided by the table and configurable.

Note that I initially tried to make "source" an `Enum`, but this turned out to create more difficulties than it solved, as it made it much harder to inject custom, unique sources for testing purposes. It would also make it very difficult to extend `vector-datasource` or 3rd party styles to additional data sources. Instead, I've replaced it with a `Source` `namedtuple` which contains both the short name (e.g: `osm`) and the long name that we use as a tag value (e.g: `openstreetmap.org`).