### PR TITLE
Add support for local storage of RAWR tiles.

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -264,9 +264,13 @@ rawr:
   # this is the parent zoom level that coordinates are expected to be grouped under
   group-zoom: 10
   queue:
+    type: sqs
     name: <sqs-queue-name>
     wait-seconds: 20
     region: us-east-1
+    # alternatively, can use a file-backed queue
+    #type: file
+    #input-file: <file containing z/x/y per line>
   postgresql:
     host: localhost
     port: 5432
@@ -278,3 +282,26 @@ rawr:
     region: us-east-1
     prefix: s3-bucket-prefix
     suffix: .zip
+  # alternatively, provide a "store" config - same as elsewhere, can be s3 or directory
+  #store:
+  #  type: directory
+  #  path: rawr_tiles
+  source:
+    type: store # type can also be "generate" or "s3"
+    store:
+      type: directory
+      name: rawr_tiles
+    # add a postgresql section if you're using "generate"
+    #postgresql:
+    #  host: null
+    #  port: null
+    #  dbname: osm
+    #  user: osm
+    table-sources:
+      planet_osm_line: &osm { name: osm, value: openstreetmap.org }
+      planet_osm_point: *osm
+      planet_osm_polygon: *osm
+      planet_osm_ways: *osm
+      planet_osm_rels: *osm
+# uncomment this to use RAWR tiles rather than go direct to the database.
+#use-rawr-tiles: true

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -1727,9 +1727,6 @@ def tilequeue_main(argv_args=None):
     if argv_args is None:
         argv_args = sys.argv[1:]
 
-    #from flamegraph.flamegraph import start_profile_thread
-    #start_profile_thread(fd=open("./perf.log", "w"), interval=0.0007)
-
     parser = TileArgumentParser()
     subparsers = parser.add_subparsers()
 

--- a/tilequeue/config.py
+++ b/tilequeue/config.py
@@ -137,6 +137,15 @@ class Configuration(object):
             yamlval = yamlval[subkey]
         return yamlval
 
+    def subtree(self, yamlkeys_str):
+        yamlkeys = yamlkeys_str.split()
+        yamlval = self.yml
+        for subkey in yamlkeys:
+            yamlval = yamlval.get(subkey)
+            if yamlval is None:
+                break
+        return yamlval
+
 
 def default_yml_config():
     return {

--- a/tilequeue/query/__init__.py
+++ b/tilequeue/query/__init__.py
@@ -72,13 +72,13 @@ def _make_rawr_fetcher(cfg, layer_data, query_cfg, io_pool):
         source_value = data['value']
         table_sources[tbl] = Source(source_name, source_value)
 
-    # set type to "generate", and provide a postgresql subkey, to generate
-    # RAWR tiles directly, rather than trying to load them from S3. this can
-    # be useful for standalone use and testing.
-    #
-    # other types are:
-    #   s3 - to fetch RAWR tiles from S3
-    #   source - to fetch RAWR tiles from any tilequeue tile source
+    # source types are:
+    #   s3       - to fetch RAWR tiles from S3
+    #   store    - to fetch RAWR tiles from any tilequeue tile source
+    #   generate - to generate RAWR tiles directly, rather than trying to load
+    #              them from S3. this can be useful for standalone use and
+    #              testing. provide a postgresql subkey for database connection
+    #              settings.
     source_type = rawr_source_yaml.get('type')
 
     if source_type == 's3':
@@ -97,7 +97,7 @@ def _make_rawr_fetcher(cfg, layer_data, query_cfg, io_pool):
         storage = RawrS3Source(s3_client, bucket, prefix, suffix,
                                table_sources, io_pool, allow_missing_tiles)
 
-    elif source_type == 'generate-from-scratch':
+    elif source_type == 'generate':
         from raw_tiles.source.conn import ConnectionContextManager
         from raw_tiles.source.osm import OsmSource
 

--- a/tilequeue/query/__init__.py
+++ b/tilequeue/query/__init__.py
@@ -95,7 +95,7 @@ def _make_rawr_fetcher(cfg, layer_data, query_cfg, io_pool):
         from tilequeue.rawr import RawrS3Source
         s3_client = boto3.client('s3')
         storage = RawrS3Source(s3_client, bucket, prefix, suffix,
-                               table_sources, io_pool, allow_missing_tiles)
+                               table_sources, allow_missing_tiles)
 
     elif source_type == 'generate':
         from raw_tiles.source.conn import ConnectionContextManager

--- a/tilequeue/query/__init__.py
+++ b/tilequeue/query/__init__.py
@@ -72,12 +72,16 @@ def _make_rawr_fetcher(cfg, layer_data, query_cfg, io_pool):
         source_value = data['value']
         table_sources[tbl] = Source(source_name, source_value)
 
-    # set this flag, and provide a postgresql subkey, to generate RAWR tiles
-    # directly, rather than trying to load them from S3. this can be useful
-    # for standalone use and testing.
-    is_s3_storage = not rawr_source_yaml.get('generate-from-scratch')
+    # set type to "generate", and provide a postgresql subkey, to generate
+    # RAWR tiles directly, rather than trying to load them from S3. this can
+    # be useful for standalone use and testing.
+    #
+    # other types are:
+    #   s3 - to fetch RAWR tiles from S3
+    #   source - to fetch RAWR tiles from any tilequeue tile source
+    source_type = rawr_source_yaml.get('type')
 
-    if is_s3_storage:
+    if source_type == 's3':
         bucket = rawr_source_yaml.get('bucket')
         assert bucket, 'Missing rawr sink bucket'
         prefix = rawr_source_yaml.get('prefix')
@@ -93,7 +97,7 @@ def _make_rawr_fetcher(cfg, layer_data, query_cfg, io_pool):
         storage = RawrS3Source(s3_client, bucket, prefix, suffix,
                                table_sources, io_pool, allow_missing_tiles)
 
-    else:
+    elif source_type == 'generate-from-scratch':
         from raw_tiles.source.conn import ConnectionContextManager
         from raw_tiles.source.osm import OsmSource
 
@@ -103,6 +107,19 @@ def _make_rawr_fetcher(cfg, layer_data, query_cfg, io_pool):
         conn_ctx = ConnectionContextManager(postgresql_cfg)
         rawr_osm_source = OsmSource(conn_ctx)
         storage = _NullRawrStorage(rawr_osm_source, table_sources)
+
+    elif source_type == 'store':
+        from tilequeue.store import make_store
+        from tilequeue.rawr import RawrStoreSource
+
+        store_cfg = rawr_source_yaml.get('store')
+        store = make_store(store_cfg,
+                           credentials=cfg.subtree('aws credentials'))
+        storage = RawrStoreSource(store, table_sources)
+
+    else:
+        assert False, 'Source type %r not understood. ' \
+            'Options are s3, generate and store.' % (source_type,)
 
     # TODO: this needs to be configurable, everywhere!
     max_z = 16

--- a/tilequeue/rawr.py
+++ b/tilequeue/rawr.py
@@ -525,7 +525,9 @@ def make_rawr_queue(name, region, wait_time_secs):
     return rawr_queue
 
 
-class RawrMemQueue(object):
+class RawrFileQueue(object):
+
+    """A source of RAWR tile jobs loaded from a text file."""
 
     Handle = namedtuple('Handle', 'payload')
 
@@ -556,10 +558,10 @@ class RawrMemQueue(object):
 def make_rawr_queue_from_yaml(rawr_queue_yaml, msg_marshaller):
     rawr_queue_type = rawr_queue_yaml.get('type', 'sqs')
 
-    if rawr_queue_type == 'mem':
+    if rawr_queue_type == 'file':
         input_file = rawr_queue_yaml.get('input-file')
         assert input_file, 'Missing input-file for memory RAWR queue'
-        rawr_queue = RawrMemQueue(input_file, msg_marshaller)
+        rawr_queue = RawrFileQueue(input_file, msg_marshaller)
 
     else:
         name = rawr_queue_yaml.get('name')

--- a/tilequeue/store.py
+++ b/tilequeue/store.py
@@ -352,3 +352,31 @@ def write_tile_if_changed(store, tile_data, coord, format, layer):
         return True
     else:
         return False
+
+
+def make_store(yml, credentials={}):
+    store_type = yml.get('type')
+
+    if store_type == 'directory':
+        path = yml.get('path')
+        name = yml.get('name')
+        return make_tile_file_store(path or name)
+
+    elif store_type == 's3':
+        bucket = yml.get('name')
+        reduced_redundancy = yml.get('reduced-redundancy')
+        date_prefix = yml.get('date-prefix')
+        delete_retry_interval = yml.get('delete-retry-interval')
+
+        assert credentials, 'S3 store configured, but no AWS credentials ' \
+            'provided. AWS credentials are required to use S3.'
+        aws_access_key_id = credentials.get('aws_access_key_id')
+        aws_secret_access_key = credentials.get('aws_secret_access_key')
+
+        return make_s3_store(
+            bucket, aws_access_key_id, aws_secret_access_key, path=path,
+            reduced_redundancy=reduced_redundancy, date_prefix=date_prefix,
+            delete_retry_interval=delete_retry_interval)
+
+    else:
+        raise ValueError('Unrecognized store type: `{}`'.format(store_type))


### PR DESCRIPTION
Both for reading and writing. This patch means that it's possible to configure a store to round-trip RAWR tiles locally. For example, with the following RAWR config:

```yaml
rawr:
  group-zoom: 10
  queue:
    type: mem
    name: myrawrqueue
    input-file: rawr_input.txt # this just contains 10/163/395
  postgresql:
    host: null
    port: 5432
    dbname: california
    user: matt
    password: null
  store:
    type: directory
    path: rawr_tiles
  source:
    type: store
    store:
      type: directory
      name: rawr_tiles
    postgresql:
      host: null
      port: null
      dbname: california
      user: matt
    table-sources:
      planet_osm_line: &osm { name: osm, value: openstreetmap.org }
      planet_osm_point: *osm
      planet_osm_polygon: *osm
      planet_osm_ways: *osm
      planet_osm_rels: *osm
use-rawr-tiles: true
```

I'm able to run:

```
tilequeue rawr-process --config config.yaml
tilequeue tile --config config.yaml 16/10475/25320
```

And generate an empty tile. Intentionally; that tile has nothing in it - easier to check that for correctness than a few pages of GeoJSON!