### PR TITLE
Various RAWR tile fixes

### DIFF
--- a/tests/test_query_common.py
+++ b/tests/test_query_common.py
@@ -1,0 +1,45 @@
+import unittest
+
+
+class TestCommon(unittest.TestCase):
+
+    def test_parse_shape_types(self):
+        from tilequeue.query.common import ShapeType
+
+        def _test(expects, inputs):
+            self.assertEquals(set(expects), ShapeType.parse_set(inputs))
+
+        # basic types
+        _test([ShapeType.point], ['point'])
+        _test([ShapeType.line], ['line'])
+        _test([ShapeType.polygon], ['polygon'])
+
+        # should be case insensitive
+        _test([ShapeType.point], ['Point'])
+        _test([ShapeType.line], ['LINE'])
+        _test([ShapeType.polygon], ['Polygon'])
+
+        # should handle OGC-style names, including Multi*
+        _test([ShapeType.point], ['MultiPoint'])
+        _test([ShapeType.line], ['LineString'])
+        _test([ShapeType.line], ['MultiLineString'])
+        _test([ShapeType.polygon], ['MultiPolygon'])
+
+        # should handle multiple, repeated names
+        _test([ShapeType.point], ['Point', 'MultiPoint'])
+        _test([
+            ShapeType.point,
+            ShapeType.line,
+            ShapeType.polygon,
+        ], [
+            'Point', 'MultiPoint',
+            'Line', 'LineString', 'MultiLineString',
+            'Polygon', 'MultiPolygon'
+        ])
+
+        # should return None rather than an empty set.
+        self.assertEquals(None, ShapeType.parse_set([]))
+
+        # should throw KeyError if the name isn't recognised
+        with self.assertRaises(KeyError):
+            ShapeType.parse_set(['MegaPolygon'])

--- a/tilequeue/query/__init__.py
+++ b/tilequeue/query/__init__.py
@@ -141,7 +141,7 @@ def _make_rawr_fetcher(cfg, layer_data, query_cfg, io_pool):
 
 
 def _make_layer_info(layer_data, process_yaml_cfg):
-    from tilequeue.query.common import LayerInfo, parse_shape_types
+    from tilequeue.query.common import LayerInfo, ShapeType
 
     layers = {}
     functions = _parse_yaml_functions(process_yaml_cfg)
@@ -149,7 +149,7 @@ def _make_layer_info(layer_data, process_yaml_cfg):
     for layer_datum in layer_data:
         name = layer_datum['name']
         min_zoom_fn, props_fn = functions[name]
-        shape_types = parse_shape_types(layer_datum['geometry_types'])
+        shape_types = ShapeType.parse_set(layer_datum['geometry_types'])
         layer_info = LayerInfo(min_zoom_fn, props_fn, shape_types)
         layers[name] = layer_info
 

--- a/tilequeue/query/__init__.py
+++ b/tilequeue/query/__init__.py
@@ -141,7 +141,7 @@ def _make_rawr_fetcher(cfg, layer_data, query_cfg, io_pool):
 
 
 def _make_layer_info(layer_data, process_yaml_cfg):
-    from tilequeue.query.common import LayerInfo
+    from tilequeue.query.common import LayerInfo, parse_shape_types
 
     layers = {}
     functions = _parse_yaml_functions(process_yaml_cfg)
@@ -149,21 +149,11 @@ def _make_layer_info(layer_data, process_yaml_cfg):
     for layer_datum in layer_data:
         name = layer_datum['name']
         min_zoom_fn, props_fn = functions[name]
-        shape_types = _parse_shape_types(layer_datum['geometry_types'])
+        shape_types = parse_shape_types(layer_datum['geometry_types'])
         layer_info = LayerInfo(min_zoom_fn, props_fn, shape_types)
         layers[name] = layer_info
 
     return layers
-
-
-def _parse_shape_types(inputs):
-    outputs = set()
-    for value in inputs:
-        if value.startswith('Multi'):
-            value = value[len('Multi'):]
-        outputs.add(value.lower())
-
-    return outputs or None
 
 
 def _parse_yaml_functions(process_yaml_cfg):

--- a/tilequeue/query/common.py
+++ b/tilequeue/query/common.py
@@ -26,6 +26,21 @@ class ShapeType(Enum):
     line = 2
     polygon = 3
 
+    # aliases, don't use these directly!
+    multipoint = 1
+    linestring = 2
+    multilinestring = 2
+    multipolygon = 3
+
+    @classmethod
+    def parse_set(cls, inputs):
+        outputs = set()
+        for value in inputs:
+            t = cls[value.lower()]
+            outputs.add(t)
+
+        return outputs or None
+
 
 # determine the shape type from the raw WKB bytes. this means we don't have to
 # parse the WKB, which can be an expensive operation for large polygons.
@@ -43,25 +58,6 @@ def wkb_shape_type(wkb):
         return ShapeType.polygon
     else:
         assert False, "WKB shape type %d not understood." % (typ,)
-
-
-def parse_shape_types(inputs):
-    lookup = {
-        'point': ShapeType.point,
-        'multipoint': ShapeType.point,
-        'linestring': ShapeType.line,
-        'multilinestring': ShapeType.line,
-        'polygon': ShapeType.polygon,
-        'multipolygon': ShapeType.polygon,
-    }
-    outputs = set()
-    for value in inputs:
-        t = lookup.get(value.lower())
-        if t is None:
-            raise ValueError("%r not understood as shape type" % value)
-        outputs.add(t)
-
-    return outputs or None
 
 
 def deassoc(x):

--- a/tilequeue/query/common.py
+++ b/tilequeue/query/common.py
@@ -292,11 +292,11 @@ def mz_calculate_transit_routes_and_score(osm, node_id, way_id, rel_id):
         if route:
             route_name = mz_transit_route_name(rel.tags)
             routes_lookup[route].add(route_name)
-    trains = routes_lookup['train']
-    subways = routes_lookup['subway']
-    light_rails = routes_lookup['light_rail']
-    trams = routes_lookup['tram']
-    railways = routes_lookup['railway']
+    trains = list(sorted(routes_lookup['train']))
+    subways = list(sorted(routes_lookup['subway']))
+    light_rails = list(sorted(routes_lookup['light_rail']))
+    trams = list(sorted(routes_lookup['tram']))
+    railways = list(sorted(routes_lookup['railway']))
     del routes_lookup
 
     # if a station is an interchange between mainline rail and subway or

--- a/tilequeue/query/rawr.py
+++ b/tilequeue/query/rawr.py
@@ -199,7 +199,7 @@ class OsmRawrLookup(object):
     def relation(self, rel_id):
         "Returns the Relation object with the given ID."
 
-        return self.relations[rel_id]
+        return self.relations.get(rel_id)
 
     def way(self, way_id):
         """
@@ -207,7 +207,7 @@ class OsmRawrLookup(object):
         given way.
         """
 
-        return self.ways[way_id]
+        return self.ways.get(way_id)
 
     def node(self, node_id):
         """
@@ -215,7 +215,7 @@ class OsmRawrLookup(object):
         given node.
         """
 
-        return self.nodes[node_id]
+        return self.nodes.get(node_id)
 
     def transit_relations(self, rel_id):
         "Return transit relations containing the relation with the given ID."
@@ -304,14 +304,20 @@ def _make_meta(source, fid, shape_type, osm):
     # fetch ways and relations for any node
     if fid >= 0 and shape_type == ShapeType.point:
         for way_id in osm.ways_using_node(fid):
-            ways.append(osm.way(way_id))
+            way = osm.way(way_id)
+            if way:
+                ways.append(way)
         for rel_id in osm.relations_using_node(fid):
-            rels.append(osm.relation(rel_id))
+            rel = osm.relation(rel_id)
+            if rel:
+                rels.append(rel)
 
     # and relations for any way
     if fid >= 0 and shape_type == ShapeType.line:
         for rel_id in osm.relations_using_way(fid):
-            rels.append(osm.relation(rel_id))
+            rel = osm.relation(rel_id)
+            if rel:
+                rels.append(rel)
 
     # have to transform the Relation object into a dict, which is
     # what the functions called on this data expect.

--- a/tilequeue/rawr.py
+++ b/tilequeue/rawr.py
@@ -261,8 +261,13 @@ class EmptyToiIntersector(object):
             hits=0,
             misses=len(coords),
             n_toi=0,
+            cached=False,
         )
-        return [], metrics
+        timing = dict(
+            fetch=0,
+            intersect=0,
+        )
+        return [], metrics, timing
 
 
 class RawrTileGenerationPipeline(object):

--- a/tilequeue/tile.py
+++ b/tilequeue/tile.py
@@ -104,13 +104,18 @@ coord_mercator_point_zoom = math.log(earth_circum) / math.log(2)
 half_earth_circum = earth_circum / 2
 
 
-def mercator_point_to_coord(z, x, y):
+def mercator_point_to_coord_fractional(z, x, y):
     coord = Coordinate(
         column=x + half_earth_circum,
         row=half_earth_circum - y,
         zoom=coord_mercator_point_zoom,
     )
-    coord = coord.zoomTo(z).container()
+    coord = coord.zoomTo(z)
+    return coord
+
+
+def mercator_point_to_coord(z, x, y):
+    coord = mercator_point_to_coord_fractional(z, x, y).container()
     return coord
 
 


### PR DESCRIPTION
A slightly random grab-bag of changes that were necessary to get RAWR tiles rendering in a not-awful way.

* Cache the bounds of a `LazyShape`, and use that to skip unnecessary calls to geometry intersection. This doesn't save as much time as I'd have hoped, but it seems like a relatively benign bit of code to leave in.
* Store sorted list of route names, rather than set. Some versions of `ujson` seem to be unhappy with serialising a set. I think the version we're using in prod is okay, but I managed to randomly update mine locally while playing around with different Shapely versions.
* Handle missing nodes, ways and relations in the index. In an attempt at efficiency, I try to only index elements which are "interesting" and have a high likelihood of being looked up. However, at index-build time we don't have full information about relation membership, so there can be members of relations which I didn't deem "interesting". I think this is okay, and these elements wouldn't have contributed to the tile data.
* Be consistent about `line` / `linestring` usage. Move it all to `Enum`-land instead.
* Handle small numerical precision issues in conversion of bounding box to tile coverage. This was causing a slight (around 1e-6) change in coordinates to grab the data for the tile above, most of the contents of which were promptly discarded as they were outside the bounding box. Added a test for this too.