### PR TITLE
Simplify coord -> queue msg handle mappings

### DIFF
--- a/tests/queue/test_msg.py
+++ b/tests/queue/test_msg.py
@@ -88,19 +88,17 @@ class SingleMessageTrackerTest(unittest.TestCase):
 
     def test_track_and_done(self):
         from tilequeue.tile import deserialize_coord
-        from tilequeue.queue import MessageHandle
-        from tilequeue.queue.message import QueueMessageHandle
-        msg_handle = MessageHandle('handle', 'payload')
+        from tilequeue.queue.message import QueueHandle
         queue_id = 1
-        queue_msg_handle = QueueMessageHandle(queue_id, msg_handle)
+        queue_handle = QueueHandle(queue_id, 'handle')
         coords = [deserialize_coord('1/1/1')]
-        coord_handles = self.tracker.track(queue_msg_handle, coords)
+        coord_handles = self.tracker.track(queue_handle, coords)
         self.assertEqual(1, len(coord_handles))
         coord_handle = coord_handles[0]
-        self.assertIs(queue_msg_handle, coord_handle)
+        self.assertIs(queue_handle, coord_handle)
 
-        returned_msg_handle, all_done = self.tracker.done(coord_handle)
-        self.assertIs(queue_msg_handle, returned_msg_handle)
+        returned_queue_handle, all_done = self.tracker.done(coord_handle)
+        self.assertIs(queue_handle, returned_queue_handle)
         self.assertTrue(all_done)
 
 
@@ -112,21 +110,19 @@ class MultipleMessageTrackerTest(unittest.TestCase):
 
     def test_track_and_done(self):
         from tilequeue.tile import deserialize_coord
-        from tilequeue.queue import MessageHandle
-        from tilequeue.queue.message import QueueMessageHandle
-        msg_handle = MessageHandle('handle', 'payload')
+        from tilequeue.queue.message import QueueHandle
         queue_id = 1
-        queue_msg_handle = QueueMessageHandle(queue_id, msg_handle)
+        queue_handle = QueueHandle(queue_id, 'handle')
         coords = map(deserialize_coord, ('1/1/1', '2/2/2'))
-        coord_handles = self.tracker.track(queue_msg_handle, coords)
+        coord_handles = self.tracker.track(queue_handle, coords)
         self.assertEqual(2, len(coord_handles))
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             self.tracker.done('bogus-coord-handle')
 
-        msg_handle_result, all_done = self.tracker.done(coord_handles[0])
+        queue_handle_result, all_done = self.tracker.done(coord_handles[0])
         self.assertFalse(all_done)
 
-        msg_handle_result, all_done = self.tracker.done(coord_handles[1])
+        queue_handle_result, all_done = self.tracker.done(coord_handles[1])
         self.assertTrue(all_done)
-        self.assertIs(queue_msg_handle, msg_handle_result)
+        self.assertIs(queue_handle, queue_handle_result)

--- a/tests/queue/test_msg.py
+++ b/tests/queue/test_msg.py
@@ -105,8 +105,10 @@ class SingleMessageTrackerTest(unittest.TestCase):
 class MultipleMessageTrackerTest(unittest.TestCase):
 
     def setUp(self):
+        from mock import MagicMock
         from tilequeue.queue.message import MultipleMessagesPerCoordTracker
-        self.tracker = MultipleMessagesPerCoordTracker()
+        msg_tracker_logger = MagicMock()
+        self.tracker = MultipleMessagesPerCoordTracker(msg_tracker_logger)
 
     def test_track_and_done(self):
         from tilequeue.tile import deserialize_coord

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -230,14 +230,9 @@ def make_tile_queue(queue_yaml_cfg, all_cfg, redis_client=None):
         queue_type = queue_yaml_cfg.get('type')
         assert queue_type, 'Missing queue type'
         if queue_type == 'sqs':
-            aws_access_key_id = None
-            aws_secret_access_key = None
-            aws_cfg = all_cfg.get('aws')
-            if aws_cfg:
-                aws_access_key_id = aws_cfg.get('aws_access_key_id')
-                aws_secret_access_key = aws_cfg.get('aws_secret_access_key')
-            tile_queue = make_sqs_queue(
-                queue_name, aws_access_key_id, aws_secret_access_key)
+            region = queue_yaml_cfg.get('region')
+            assert region, 'Missing queue region'
+            tile_queue = make_sqs_queue(queue_name, region)
         elif queue_type == 'mem':
             from tilequeue.queue import MemoryQueue
             tile_queue = MemoryQueue()

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -269,7 +269,9 @@ def make_msg_tracker(msg_tracker_yaml):
             return SingleMessagePerCoordTracker()
         elif msg_tracker_type == 'multiple':
             from tilequeue.queue.message import MultipleMessagesPerCoordTracker
-            return MultipleMessagesPerCoordTracker()
+            from tilequeue.log import MultipleMessagesTrackerLogger
+            msg_tracker_logger = MultipleMessagesTrackerLogger()
+            return MultipleMessagesPerCoordTracker(msg_tracker_logger)
         else:
             assert 0, 'Unknown message tracker type: %s' % msg_tracker_type
 

--- a/tilequeue/log.py
+++ b/tilequeue/log.py
@@ -165,3 +165,27 @@ class JsonRawrProcessingLogger(object):
         )
         json_str = json.dumps(json_obj)
         self.logger.info(json_str)
+
+
+class MultipleMessagesTrackerLogger(object):
+
+    def __init__(self, logger):
+        self.logger = logger
+
+    def _log(self, msg, coord_id, queue_handle_id):
+        z, x, y = coord_id
+        json_obj = dict(
+            type=log_level_name(LogLevel.WARNING),
+            category=log_category_name(LogCategory.PROCESS),
+            msg=msg,
+            coord=dict(z=z, x=x, y=y),
+            handle=queue_handle_id,
+        )
+        json_str = json.dumps(json_obj)
+        self.logger.warning(json_str)
+
+    def unknown_queue_handle_id(self, coord_id, queue_handle_id):
+        self._log('Unknown queue_handle_id', coord_id, queue_handle_id)
+
+    def unknown_coord_id(self, coord_id, queue_handle_id):
+        self._log('Unknown coord_id', coord_id, queue_handle_id)

--- a/tilequeue/queue/sqs.py
+++ b/tilequeue/queue/sqs.py
@@ -1,57 +1,88 @@
-from boto import connect_sqs
-from boto.sqs.message import RawMessage
 from tilequeue.queue import MessageHandle
 from tilequeue.utils import grouper
 
 
 class SqsQueue(object):
 
-    def __init__(self, sqs_queue, read_size=10):
-        self.sqs_queue = sqs_queue
+    def __init__(self, sqs_client, queue_url, read_size,
+                 recv_wait_time_seconds):
+        self.sqs_client = sqs_client
+        self.queue_url = queue_url
         self.read_size = read_size
+        self.recv_wait_time_seconds = recv_wait_time_seconds
 
     def enqueue(self, payload):
-        message = RawMessage()
-        message.set_body(payload)
-        self.sqs_queue.write(message)
+        return self.sqs_client.send(
+            QueueUrl=self.queue_url,
+            MessageBody=payload,
+        )
 
     def enqueue_batch(self, payloads):
         # sqs can only send 10 messages at once
         for payloads_chunk in grouper(payloads, 10):
-            msg_tuples = []
+            msgs = []
             for i, payload in enumerate(payloads_chunk):
-                msg_tuples.append((str(i), payload, 0))
-            self.sqs_queue.write_batch(msg_tuples)
+                msg_id = str(i)
+                msg = dict(
+                    Id=msg_id,
+                    MessageBody=payload,
+                )
+                msgs.append(msg)
+            resp = self.sqs_client.send_message_batch(msgs)
+            if resp['ResponseMetadata']['HTTPStatusCode'] != 200:
+                raise Exception('Invalid status code from sqs: %s' %
+                                resp['ResponseMetadata']['HTTPStatusCode'])
+            failed_messages = resp.get('Failed')
+            if failed_messages:
+                # TODO maybe retry failed messages if not sender's fault? up to
+                # a certain maximum number of attempts?
+                # http://boto3.readthedocs.io/en/latest/reference/services/sqs.html#SQS.Client.send_message_batch # noqa
+                raise Exception('Messages failed to send to sqs: %s' %
+                                len(failed_messages))
 
     def read(self):
         msg_handles = []
-        sqs_messages = self.sqs_queue.get_messages(
-            num_messages=self.read_size, attributes=["SentTimestamp"])
+        resp = self.sqs_client.receive_message(
+            QueueUrl=self.queue_url,
+            MaxNumberOfMessages=self.read_size,
+            AttributeNames=('SentTimestamp',),
+            WaitTimeSeconds=self.recv_wait_time_seconds,
+        )
+        if resp['ResponseMetadata']['HTTPStatusCode'] != 200:
+            raise Exception('Invalid status code from sqs: %s' %
+                            resp['ResponseMetadata']['HTTPStatusCode'])
+
+        sqs_messages = resp.get('Messages')
+        if not sqs_messages:
+            return None
         for sqs_message in sqs_messages:
-            payload = sqs_message.get_body()
+            payload = sqs_message['Body']
             try:
-                timestamp = float(sqs_message.attributes.get('SentTimestamp'))
+                timestamp = float(sqs_message['Attributes']['SentTimestamp'])
             except (TypeError, ValueError):
                 timestamp = None
+            sqs_handle = sqs_message['ReceiptHandle']
 
-            metadata = dict(
-                queue_name=self.sqs_queue.name,
-                timestamp=timestamp,
-            )
-            msg_handle = MessageHandle(sqs_message, payload, metadata)
+            metadata = dict(timestamp=timestamp)
+            msg_handle = MessageHandle(sqs_handle, payload, metadata)
             msg_handles.append(msg_handle)
+
         return msg_handles
 
     def job_done(self, msg_handle):
-        self.sqs_queue.delete_message(msg_handle.handle)
+        self.sqs_client.delete_message(
+            QueueUrl=self.queue_url,
+            ReceiptHandle=msg_handle.handle,
+        )
 
     def clear(self):
         n = 0
         while True:
-            msgs = self.sqs_queue.get_messages(self.read_size)
+            msgs = self.read()
             if not msgs:
                 break
-            self.sqs_queue.delete_message_batch(msgs)
+            for msg in msgs:
+                self.job_done(msg)
             n += len(msgs)
         return n
 
@@ -59,12 +90,13 @@ class SqsQueue(object):
         pass
 
 
-def make_sqs_queue(
-        queue_name, aws_access_key_id=None, aws_secret_access_key=None):
-    conn = connect_sqs(aws_access_key_id, aws_secret_access_key)
-    queue = conn.get_queue(queue_name)
-    assert queue is not None, \
-        'Could not get sqs queue with name: %s' % queue_name
-    queue.set_message_class(RawMessage)
+def make_sqs_queue(name, region):
+    import boto3
+    sqs_client = boto3.client('sqs', region_name=region)
+    resp = sqs_client.get_queue_url(QueueName=name)
+    assert resp['ResponseMetadata']['HTTPStatusCode'] == 200, \
+        'Failed to get queue url for: %s' % name
+    queue_url = resp['QueueUrl']
     read_size = 10
-    return SqsQueue(queue, read_size)
+    recv_wait_time_seconds = 20
+    return SqsQueue(sqs_client, queue_url, read_size, recv_wait_time_seconds)

--- a/tilequeue/queue/sqs.py
+++ b/tilequeue/queue/sqs.py
@@ -69,10 +69,10 @@ class SqsQueue(object):
 
         return msg_handles
 
-    def job_done(self, msg_handle):
+    def job_done(self, handle):
         self.sqs_client.delete_message(
             QueueUrl=self.queue_url,
-            ReceiptHandle=msg_handle.handle,
+            ReceiptHandle=handle,
         )
 
     def clear(self):
@@ -82,7 +82,7 @@ class SqsQueue(object):
             if not msgs:
                 break
             for msg in msgs:
-                self.job_done(msg)
+                self.job_done(msg.handle)
             n += len(msgs)
         return n
 

--- a/tilequeue/rawr.py
+++ b/tilequeue/rawr.py
@@ -546,7 +546,8 @@ def make_rawr_queue(name, region, wait_time_secs):
     import boto3
     sqs_client = boto3.client('sqs', region_name=region)
     resp = sqs_client.get_queue_url(QueueName=name)
-    assert resp['ResponseMetadata']['HTTPStatusCode'] == 200
+    assert resp['ResponseMetadata']['HTTPStatusCode'] == 200, \
+        'Failed to get queue url for: %s' % name
     queue_url = resp['QueueUrl']
     from tilequeue.rawr import SqsQueue
     rawr_queue = SqsQueue(sqs_client, queue_url, wait_time_secs)

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -8,7 +8,7 @@ from tilequeue.metatile import common_parent
 from tilequeue.metatile import make_metatiles
 from tilequeue.process import convert_source_data_to_feature_layers
 from tilequeue.process import process_coord
-from tilequeue.queue.message import QueueMessageHandle
+from tilequeue.queue.message import QueueHandle
 from tilequeue.store import write_tile_if_changed
 from tilequeue.tile import coord_children_range
 from tilequeue.tile import coord_to_mercator_bounds
@@ -136,9 +136,10 @@ class TileQueueReader(object):
                     break
 
                 coords = self.msg_marshaller.unmarshall(msg_handle.payload)
-                queue_msg_handle = QueueMessageHandle(queue_id, msg_handle)
+                queue_handle = QueueHandle(
+                    queue_id, msg_handle.handle, msg_handle.metadata)
                 coord_handles = self.msg_tracker.track(
-                    queue_msg_handle, coords)
+                    queue_handle, coords)
 
                 all_coords_data = []
                 top_tile = None
@@ -198,7 +199,13 @@ class TileQueueReader(object):
         # of timed-out jobs being re-added to the
         # queue until they overflow max-retries.
         try:
-            self.msg_tracker.done(coord_handle)
+            queue_handle, done = self.msg_tracker.done(coord_handle)
+            if done:
+                tile_queue = (
+                    self.queue_mapper.get_queue(queue_handle.queue_id))
+                assert tile_queue, \
+                    'Missing tile_queue: %s' % queue_handle.queue_id
+                tile_queue.job_done(queue_handle.handle)
         except Exception as e:
             stacktrace = format_stacktrace_one_line()
             self.tile_proc_logger.error(
@@ -521,14 +528,13 @@ class TileQueueWriter(object):
                 continue
 
             try:
-                queue_msg_handle, done = self.msg_tracker.done(coord_handle)
-                msg_handle = queue_msg_handle.msg_handle
+                queue_handle, done = self.msg_tracker.done(coord_handle)
                 if done:
                     tile_queue = (
-                        self.queue_mapper.get_queue(queue_msg_handle.queue_id))
+                        self.queue_mapper.get_queue(queue_handle.queue_id))
                     assert tile_queue, \
-                        'Missing tile_queue: %s' % queue_msg_handle.queue_id
-                    tile_queue.job_done(msg_handle)
+                        'Missing tile_queue: %s' % queue_handle.queue_id
+                    tile_queue.job_done(queue_handle.handle)
             except Exception as e:
                 stacktrace = format_stacktrace_one_line()
                 self.tile_proc_logger.error(
@@ -539,7 +545,7 @@ class TileQueueWriter(object):
             now = time.time()
             timing['ack_seconds'] = now - start
 
-            msg_metadata = msg_handle.metadata
+            msg_metadata = queue_handle.metadata
             time_in_queue = 0
             if msg_metadata:
                 tile_timestamp_millis = msg_metadata.get('timestamp')

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -545,13 +545,14 @@ class TileQueueWriter(object):
             now = time.time()
             timing['ack_seconds'] = now - start
 
-            msg_metadata = queue_handle.metadata
             time_in_queue = 0
-            if msg_metadata:
-                tile_timestamp_millis = msg_metadata.get('timestamp')
-                if tile_timestamp_millis is not None:
-                    tile_timestamp_seconds = tile_timestamp_millis / 1000.0
-                    time_in_queue = now - tile_timestamp_seconds
+            if queue_handle:
+                msg_metadata = queue_handle.metadata
+                if msg_metadata:
+                    tile_timestamp_millis = msg_metadata.get('timestamp')
+                    if tile_timestamp_millis is not None:
+                        tile_timestamp_seconds = tile_timestamp_millis / 1000.0
+                        time_in_queue = now - tile_timestamp_seconds
             timing['queue'] = time_in_queue
 
             layers = metadata['layers']


### PR DESCRIPTION
Connects to https://github.com/mapzen/tile-tasks/issues/290

Simplify the msg tracking logic. This should hopefully remove the errors we've been seeing. If not, instead of failing with an error, it tries to always proceed now but emit a warning in the logs for any inconsistencies.

The simplification changes:

* don't use memory ids as the indirect coord/queue handles
* use the queue message receipt handle as the key for mapping to the set of coord ids
* use a coordinate z,x,y tuple as the coord id
* use the coord_id and queue_handle_id as the coord handle, which removes the need for another intermediary mapping

The sqs queue implementation was also updated to use boto3. This was necessary to gain access to the receipt handle directly. Actually, it might have been possible with boto2 as well, but it wasn't as clear in the api, and we wanted to update to use boto3 everywhere anyway. (I thought there was an issue for this but I can't find it now).