### PR TITLE
Add support for configured nominal zoom to single tile processing.

### DIFF
--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -1538,12 +1538,18 @@ def tilequeue_process_tile(cfg, peripherals, args):
 
     data_fetcher = make_data_fetcher(cfg, layer_data, query_cfg, io_pool)
 
+    nominal_zoom = coord.zoom + cfg.metatile_zoom
     unpadded_bounds = coord_to_mercator_bounds(coord)
+
     for fetch, _ in data_fetcher.fetch_tiles([dict(coord=coord)]):
-        source_rows = fetch(coord.zoom, unpadded_bounds)
+        source_rows = fetch(nominal_zoom, unpadded_bounds)
     feature_layers = convert_source_data_to_feature_layers(
         source_rows, layer_data, unpadded_bounds, coord.zoom)
+
     cut_coords = []
+    if nominal_zoom > coord.zoom:
+        cut_coords.extend(coord_children_range(coord, nominal_zoom))
+
     formats = lookup_formats(cfg.output_formats)
     formatted_tiles, extra_data = process_coord(
         coord, coord.zoom, feature_layers, post_process_data, formats,


### PR DESCRIPTION
Only the first (zero'th) JSON tile will be output, so this isn't terribly useful in the command itself, but can be very useful when trying to replicate failures on a single (meta)tile.