### PR TITLE
Update tilequeue proc stats

### DIFF
--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -688,11 +688,12 @@ def tilequeue_process(cfg, peripherals):
 
     data_fetch = DataFetch(
         feature_fetcher, tile_input_queue, sql_data_fetch_queue, io_pool,
-        tile_proc_logger, cfg.metatile_zoom, cfg.max_zoom)
+        tile_proc_logger, stats_handler, cfg.metatile_zoom, cfg.max_zoom)
 
     data_processor = ProcessAndFormatData(
         post_process_data, formats, sql_data_fetch_queue, processor_queue,
-        cfg.buffer_cfg, output_calc_mapping, layer_data, tile_proc_logger)
+        cfg.buffer_cfg, output_calc_mapping, layer_data, tile_proc_logger,
+        stats_handler)
 
     s3_storage = S3Storage(processor_queue, s3_store_queue, io_pool, store,
                            tile_proc_logger, cfg.metatile_size)

--- a/tilequeue/stats.py
+++ b/tilequeue/stats.py
@@ -26,6 +26,12 @@ class TileProcessingStatsHandler(object):
         duration = stop_time - start_time
         self.stats.timing('process.pyramid', duration)
 
+    def fetch_error(self):
+        self.stats.incr('process.errors.fetch', 1)
+
+    def proc_error(self):
+        self.stats.incr('process.errors.process', 1)
+
 
 class RawrTileEnqueueStatsHandler(object):
 

--- a/tilequeue/stats.py
+++ b/tilequeue/stats.py
@@ -5,12 +5,12 @@ class TileProcessingStatsHandler(object):
 
     def processed_coord(self, coord_proc_data):
         with self.stats.pipeline() as pipe:
-            pipe.timing('process.fetch', coord_proc_data.timing['fetch'])
-            pipe.timing('process.process', coord_proc_data.timing['process'])
-            pipe.timing('process.upload', coord_proc_data.timing['s3'])
-            pipe.timing('process.ack', coord_proc_data.timing['ack'])
-            pipe.timing('process.time-in-queue',
-                        coord_proc_data.timing['queue'])
+            pipe.timing('process.time.fetch', coord_proc_data.timing['fetch'])
+            pipe.timing('process.time.process',
+                        coord_proc_data.timing['process'])
+            pipe.timing('process.time.upload', coord_proc_data.timing['s3'])
+            pipe.timing('process.time.ack', coord_proc_data.timing['ack'])
+            pipe.timing('process.time.queue', coord_proc_data.timing['queue'])
 
             for layer_name, features_size in coord_proc_data.size.items():
                 metric_name = 'process.size.%s' % layer_name

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -281,12 +281,13 @@ class DataFetch(object):
 
     def __init__(
             self, fetcher, input_queue, output_queue, io_pool,
-            tile_proc_logger, metatile_zoom, max_zoom):
+            tile_proc_logger, stats_handler, metatile_zoom, max_zoom):
         self.fetcher = fetcher
         self.input_queue = input_queue
         self.output_queue = output_queue
         self.io_pool = io_pool
         self.tile_proc_logger = tile_proc_logger
+        self.stats_handler = stats_handler
         self.metatile_zoom = metatile_zoom
         self.max_zoom = max_zoom
 
@@ -315,6 +316,7 @@ class DataFetch(object):
                 stacktrace = format_stacktrace_one_line()
                 self.tile_proc_logger.error(
                     'Fetch error', e, stacktrace, coord)
+                self.stats_handler.fetch_error()
 
         if not saw_sentinel:
             _force_empty_queue(self.input_queue)
@@ -360,7 +362,7 @@ class ProcessAndFormatData(object):
 
     def __init__(self, post_process_data, formats, input_queue,
                  output_queue, buffer_cfg, output_calc_mapping, layer_data,
-                 tile_proc_logger):
+                 tile_proc_logger, stats_handler):
         formats.sort(key=attrgetter('sort_key'))
         self.post_process_data = post_process_data
         self.formats = formats
@@ -370,6 +372,7 @@ class ProcessAndFormatData(object):
         self.output_calc_mapping = output_calc_mapping
         self.layer_data = layer_data
         self.tile_proc_logger = tile_proc_logger
+        self.stats_handler = stats_handler
 
     def __call__(self, stop):
         # ignore ctrl-c interrupts when run from terminal
@@ -407,6 +410,7 @@ class ProcessAndFormatData(object):
                 stacktrace = format_stacktrace_one_line()
                 self.tile_proc_logger.error(
                     'Processing error', e, stacktrace, coord)
+                self.stats_handler.proc_error()
                 continue
 
             metadata = data['metadata']


### PR DESCRIPTION
Connects to https://github.com/mapzen/tile-tasks/issues/290

I was looking through grafana and stats, and made a couple of updates:

* added fetch/proc stats that we can use to get a count on the dashboard
* namespaced timing stats more consistently

NOTE: I optimistically based this pr off of https://github.com/tilezen/tilequeue/pull/298 since some of the code was in a similar location.