### PR TITLE
Add extra data tables

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -326,5 +326,8 @@ rawr:
       planet_osm_polygon: *osm
       planet_osm_ways: *osm
       planet_osm_rels: *osm
+      wof_neighbourhood: { name: wof, value: whosonfirst.mapzen.com }
+      water_polygons: &osmdata { name: shp, value: openstreetmapdata.com }
+      land_polygons: *osmdata
 # uncomment this to use RAWR tiles rather than go direct to the database.
 #use-rawr-tiles: true

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -341,7 +341,10 @@ rawr:
   # appear in an index, so this list must be exhaustive. all OSM-based features
   # are handled by a single index of {type: osm}. other indexes are provided on
   # single table/layer combinations with the {type: simple}, providing the
-  # names of both the table and layer.
+  # names of both the table and layer. it's also possible to provide start_zoom
+  # and end_zoom parameters which control when the data is visible. note that
+  # the start_zoom is inclusive (and optional; defaults to 0) and the end_zoom
+  # is exclusive (also optional; defaults to infinity).
   indexes:
     - type: osm
     - type: simple
@@ -356,5 +359,6 @@ rawr:
     - type: simple
       table: ne_10m_urban_areas
       layer: landuse
+      end_zoom: 10
 # uncomment this to use RAWR tiles rather than go direct to the database.
 #use-rawr-tiles: true

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -329,5 +329,32 @@ rawr:
       wof_neighbourhood: { name: wof, value: whosonfirst.mapzen.com }
       water_polygons: &osmdata { name: shp, value: openstreetmapdata.com }
       land_polygons: *osmdata
+  # when a feature's shape is of the type given in the key and the feature
+  # appears in the listed layers, then generate a label centroid. multi*
+  # geometries are considered the same as single ones for the purposes of key
+  # lookup.
+  label-placement-layers:
+    point: ['earth', 'water']
+    polygon: ['buildings', 'earth', 'landuse', 'water']
+    linestring: ['earth', 'landuse', 'water']
+  # indexes to generate on the RAWR tile. features are looked up only if they
+  # appear in an index, so this list must be exhaustive. all OSM-based features
+  # are handled by a single index of {type: osm}. other indexes are provided on
+  # single table/layer combinations with the {type: simple}, providing the
+  # names of both the table and layer.
+  indexes:
+    - type: osm
+    - type: simple
+      table: wof_neighbourhood
+      layer: places
+    - type: simple
+      table: water_polygons
+      layer: water
+    - type: simple
+      table: land_polygons
+      layer: earth
+    - type: simple
+      table: ne_10m_urban_areas
+      layer: landuse
 # uncomment this to use RAWR tiles rather than go direct to the database.
 #use-rawr-tiles: true

--- a/tests/test_query_rawr.py
+++ b/tests/test_query_rawr.py
@@ -44,8 +44,9 @@ class RawrTestCase(unittest.TestCase):
 
         layers = {layer_name: LayerInfo(min_zoom_fn, props_fn)}
         storage = ConstantStorage(tables)
+        indexes_cfg = [dict(type="osm")]
         return make_rawr_data_fetcher(
-            min_z, max_z, storage, layers,
+            min_z, max_z, storage, layers, indexes_cfg,
             label_placement_layers=label_placement_layers)
 
 
@@ -482,7 +483,7 @@ class TestNameHandling(RawrTestCase):
             layers[name] = LayerInfo(min_zoom_fn, props_fn)
         storage = ConstantStorage(tables)
         fetch = make_rawr_data_fetcher(
-            top_zoom, max_zoom, storage, layers)
+            top_zoom, max_zoom, storage, layers, [dict(type="osm")])
 
         for fetcher, _ in fetch.fetch_tiles(_wrap(top_tile)):
             read_rows = fetcher(tile.zoom, coord_to_mercator_bounds(tile))

--- a/tilequeue/query/__init__.py
+++ b/tilequeue/query/__init__.py
@@ -72,6 +72,16 @@ def _make_rawr_fetcher(cfg, layer_data, query_cfg, io_pool):
         source_value = data['value']
         table_sources[tbl] = Source(source_name, source_value)
 
+    label_placement_layers = rawr_yaml.get('label-placement-layers', {})
+    for geom_type, layers in label_placement_layers.items():
+        assert geom_type in ('point', 'polygon', 'linestring'), \
+            'Geom type %r not understood, expecting point, polygon or ' \
+            'linestring.' % (geom_type,)
+        label_placement_layers[geom_type] = set(layers)
+
+    indexes_cfg = rawr_yaml.get('indexes')
+    assert indexes_cfg, 'Missing definitions of table indexes.'
+
     # source types are:
     #   s3       - to fetch RAWR tiles from S3
     #   store    - to fetch RAWR tiles from any tilequeue tile source
@@ -124,24 +134,9 @@ def _make_rawr_fetcher(cfg, layer_data, query_cfg, io_pool):
         assert False, 'Source type %r not understood. ' \
             'Options are s3, generate and store.' % (source_type,)
 
-    # TODO: this needs to be configurable, everywhere!
+    # TODO: this needs to be configurable, everywhere! this is a long term
+    # refactor - it's hard-coded in a bunch of places :-(
     max_z = 16
-
-    # TODO: put this in the config!
-    label_placement_layers = {
-        'point': set(['earth', 'water']),
-        'polygon': set(['buildings', 'earth', 'landuse', 'water']),
-        'linestring': set(['earth', 'landuse', 'water']),
-    }
-
-    # TODO: put this in the config!
-    indexes_cfg = [
-        dict(type="osm"),
-        dict(type="simple", table="wof_neighbourhood", layer="places"),
-        dict(type="simple", table="water_polygons", layer="water"),
-        dict(type="simple", table="land_polygons", layer="earth"),
-        dict(type="simple", table="ne_10m_urban_areas", layer="landuse"),
-    ]
 
     layers = _make_layer_info(layer_data, cfg.process_yaml_cfg)
 

--- a/tilequeue/query/__init__.py
+++ b/tilequeue/query/__init__.py
@@ -134,10 +134,20 @@ def _make_rawr_fetcher(cfg, layer_data, query_cfg, io_pool):
         'linestring': set(['earth', 'landuse', 'water']),
     }
 
+    # TODO: put this in the config!
+    indexes_cfg = [
+        dict(type="osm"),
+        dict(type="simple", table="wof_neighbourhood", layer="places"),
+        dict(type="simple", table="water_polygons", layer="water"),
+        dict(type="simple", table="land_polygons", layer="earth"),
+        dict(type="simple", table="ne_10m_urban_areas", layer="landuse"),
+    ]
+
     layers = _make_layer_info(layer_data, cfg.process_yaml_cfg)
 
     return make_rawr_data_fetcher(
-        group_by_zoom, max_z, storage, layers, label_placement_layers)
+        group_by_zoom, max_z, storage, layers, indexes_cfg,
+        label_placement_layers)
 
 
 def _make_layer_info(layer_data, process_yaml_cfg):


### PR DESCRIPTION
Added support for extra data tables, including indexing them. Made indexing configurable so that it is (in theory, at least) not hard-coded to our schema. Updated to match changes in https://github.com/tilezen/raw_tiles/pull/17.