### PR TITLE
Same precision for metatiles

### DIFF
--- a/tests/test_mvt.py
+++ b/tests/test_mvt.py
@@ -1,0 +1,84 @@
+import unittest
+
+
+class MapboxVectorTileTest(unittest.TestCase):
+
+    def _make_tiles(self, shape, coord, metatile_zoom):
+        from tilequeue.format import mvt_format
+        from tilequeue.process import process_coord
+        from tilequeue.tile import coord_children_range
+        from tilequeue.tile import coord_to_mercator_bounds
+
+        db_features = [dict(
+            __id__=1,
+            __geometry__=shape.wkb,
+            __properties__={},
+        )]
+
+        nominal_zoom = coord.zoom + metatile_zoom
+        unpadded_bounds = coord_to_mercator_bounds(coord)
+        feature_layers = [dict(
+            layer_datum=dict(
+                name='fake_layer',
+                geometry_types=[shape.geom_type],
+                transform_fn_names=[],
+                sort_fn_name=None,
+                is_clipped=False
+            ),
+            padded_bounds={shape.geom_type.lower(): unpadded_bounds},
+            features=db_features
+        )]
+        formats = [mvt_format]
+
+        post_process_data = {}
+        buffer_cfg = {}
+        cut_coords = list()
+        if nominal_zoom > coord.zoom:
+            cut_coords.extend(coord_children_range(coord, nominal_zoom))
+
+        def _output_fn(shape, props, fid, meta):
+            return dict(fake='data', min_zoom=0)
+
+        output_calc_mapping = dict(fake_layer=_output_fn)
+        tiles, extra = process_coord(
+            coord, coord.zoom, feature_layers, post_process_data, formats,
+            unpadded_bounds, cut_coords, buffer_cfg, output_calc_mapping)
+
+        return tiles
+
+    def _check_metatile(self, metatile_size):
+        from mock import patch
+        from shapely.geometry import box
+        from ModestMaps.Core import Coordinate
+        from tilequeue.tile import coord_to_mercator_bounds
+        from tilequeue.tile import metatile_zoom_from_size
+
+        name = 'tilequeue.format.mvt.mvt_encode'
+        with patch(name, return_value='') as encode:
+            coord = Coordinate(0, 0, 0)
+            bounds = coord_to_mercator_bounds(coord)
+            pixel_fraction = 1.0 / 4096.0
+            box_width = pixel_fraction * (bounds[2] - bounds[0])
+            box_height = pixel_fraction * (bounds[3] - bounds[1])
+            shape = box(bounds[0], bounds[1],
+                        bounds[0] + box_width,
+                        bounds[1] + box_height)
+
+            metatile_zoom = metatile_zoom_from_size(metatile_size)
+            tiles = self._make_tiles(shape, coord, metatile_zoom)
+
+            num_tiles = 0
+            for z in range(0, metatile_zoom + 1):
+                num_tiles += 4**z
+
+            self.assertEqual(num_tiles, len(tiles))
+            self.assertEqual(num_tiles, encode.call_count)
+            for posargs, kwargs in encode.call_args_list:
+                self.assertIn('extents', kwargs)
+                self.assertEquals(kwargs['extents'], 4096)
+
+    def test_single_tile(self):
+        self._check_metatile(1)
+
+    def test_metatile_size_2(self):
+        self._check_metatile(2)

--- a/tests/test_mvt.py
+++ b/tests/test_mvt.py
@@ -82,8 +82,8 @@ class MapboxVectorTileTest(unittest.TestCase):
                                                 tile_coords):
                 self.assertIn('quantize_bounds', kwargs)
                 quantize_bounds = kwargs['quantize_bounds']
-                extent = int((quantize_bounds[2] - quantize_bounds[0]) /
-                             resolution)
+                extent = int(round((quantize_bounds[2] - quantize_bounds[0]) /
+                                   resolution))
                 self.assertIn('extents', kwargs)
                 actual_extent = kwargs['extents']
                 self.assertEquals(extent, actual_extent,
@@ -95,3 +95,6 @@ class MapboxVectorTileTest(unittest.TestCase):
 
     def test_metatile_size_2(self):
         self._check_metatile(2)
+
+    def test_metatile_size_4(self):
+        self._check_metatile(4)

--- a/tilequeue/config.py
+++ b/tilequeue/config.py
@@ -1,7 +1,6 @@
 from tilequeue.tile import bounds_buffer
 from tilequeue.tile import metatile_zoom_from_size
 from yaml import load
-import math
 import os
 
 

--- a/tilequeue/config.py
+++ b/tilequeue/config.py
@@ -1,4 +1,5 @@
 from tilequeue.tile import bounds_buffer
+from tilequeue.tile import metatile_zoom_from_size
 from yaml import load
 import math
 import os
@@ -116,12 +117,7 @@ class Configuration(object):
         self.wof = self.yml.get('wof')
 
         self.metatile_size = self._cfg('metatile size')
-        if self.metatile_size is None:
-            self.metatile_zoom = 0
-        else:
-            self.metatile_zoom = int(math.log(self.metatile_size, 2))
-            assert (1 << self.metatile_zoom) == self.metatile_size, \
-                "Metatile size must be a power of two."
+        self.metatile_zoom = metatile_zoom_from_size(self.metatile_size)
 
         self.max_zoom_with_changes = self._cfg('tiles max-zoom-with-changes')
         assert self.max_zoom_with_changes > self.metatile_zoom

--- a/tilequeue/format/__init__.py
+++ b/tilequeue/format/__init__.py
@@ -30,9 +30,9 @@ class OutputFormat(object):
         return self.extension == other.extension
 
     def format_tile(self, tile_data_file, feature_layers, zoom, bounds_merc,
-                    bounds_lnglat):
+                    bounds_lnglat, extents=4096):
         self.format_fn(tile_data_file, feature_layers, zoom, bounds_merc,
-                       bounds_lnglat)
+                       bounds_lnglat, extents)
 
 
 def convert_feature_layers_to_dict(feature_layers):
@@ -47,7 +47,7 @@ def convert_feature_layers_to_dict(feature_layers):
 
 
 # consistent facade around all formatters that we use
-def format_json(fp, feature_layers, zoom, bounds_merc, bounds_lnglat):
+def format_json(fp, feature_layers, zoom, bounds_merc, bounds_lnglat, extents):
     if len(feature_layers) == 1:
         json_encode_single_layer(fp, feature_layers[0]['features'], zoom)
         return
@@ -56,12 +56,13 @@ def format_json(fp, feature_layers, zoom, bounds_merc, bounds_lnglat):
         json_encode_multiple_layers(fp, features_by_layer, zoom)
 
 
-def format_topojson(fp, feature_layers, zoom, bounds_merc, bounds_lnglat):
+def format_topojson(fp, feature_layers, zoom, bounds_merc, bounds_lnglat,
+                    extents):
     features_by_layer = convert_feature_layers_to_dict(feature_layers)
-    topojson_encode(fp, features_by_layer, bounds_lnglat)
+    topojson_encode(fp, features_by_layer, bounds_lnglat, extents)
 
 
-def format_mvt(fp, feature_layers, zoom, bounds_merc, bounds_lnglat):
+def format_mvt(fp, feature_layers, zoom, bounds_merc, bounds_lnglat, extents):
     mvt_layers = []
     for feature_layer in feature_layers:
         mvt_features = []
@@ -77,7 +78,7 @@ def format_mvt(fp, feature_layers, zoom, bounds_merc, bounds_lnglat):
             features=mvt_features,
         )
         mvt_layers.append(mvt_layer)
-    mvt_encode(fp, mvt_layers, bounds_merc)
+    mvt_encode(fp, mvt_layers, bounds_merc, extents)
 
 
 def format_vtm(fp, feature_layers, zoom, bounds_merc, bounds_lnglat):

--- a/tilequeue/format/mvt.py
+++ b/tilequeue/format/mvt.py
@@ -2,12 +2,12 @@ from mapbox_vector_tile.encoder import on_invalid_geometry_make_valid
 from mapbox_vector_tile import encode as mvt_encode
 
 
-def encode(fp, feature_layers, bounds_merc):
+def encode(fp, feature_layers, bounds_merc, extents=4096):
     tile = mvt_encode(
         feature_layers,
         quantize_bounds=bounds_merc,
         on_invalid_geometry=on_invalid_geometry_make_valid,
         round_fn=round,
-        extents=4096,
+        extents=extents,
     )
     fp.write(tile)

--- a/tilequeue/format/mvt.py
+++ b/tilequeue/format/mvt.py
@@ -8,5 +8,6 @@ def encode(fp, feature_layers, bounds_merc):
         quantize_bounds=bounds_merc,
         on_invalid_geometry=on_invalid_geometry_make_valid,
         round_fn=round,
+        extents=4096,
     )
     fp.write(tile)

--- a/tilequeue/format/topojson.py
+++ b/tilequeue/format/topojson.py
@@ -65,7 +65,7 @@ def diff_encode(line, transform):
     return coords[:1] + [(x, y) for (x, y) in diffs if (x, y) != (0, 0)]
 
 
-def encode(file, features_by_layer, bounds):
+def encode(file, features_by_layer, bounds, size=4096):
     """ Encode a dict of layername: (shape, props, id) features into a
         TopoJSON stream.
 
@@ -74,8 +74,11 @@ def encode(file, features_by_layer, bounds):
         Geometries in the features list are assumed to be unprojected
         lon, lats.  Bounds are given in geographic coordinates as
         (xmin, ymin, xmax, ymax).
+
+        Size is the number of integer coordinates which span the extent
+        of the tile.
     """
-    transform, forward = get_transform(bounds)
+    transform, forward = get_transform(bounds, size=size)
     arcs = []
 
     geometries_by_layer = {}

--- a/tilequeue/tile.py
+++ b/tilequeue/tile.py
@@ -356,3 +356,14 @@ def coord_is_valid(coord, max_zoom=20):
     if coord.column >= max_colrow or coord.row >= max_colrow:
         return False
     return True
+
+
+def metatile_zoom_from_size(metatile_size):
+    metatile_zoom = 0
+
+    if metatile_size is not None:
+        metatile_zoom = int(math.log(metatile_size, 2))
+        assert (1 << metatile_zoom) == metatile_size, \
+            "Metatile size must be a power of two."
+
+    return metatile_zoom


### PR DESCRIPTION
This makes it so that all the tiles in a metatile have the same precision. That means that if the "256px" tiles have extent 4096, the "512px" ones are 8192 and so forth. Also adds a test to check that "1024px" tiles come out correctly when configured.

There will be a follow-on PR to make some of these optional, in case we don't want the "1024px" tile (although it will still have to be generated, just missing from the formatted coordinates).