### PR TITLE
Optionally disable 1024px tile

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -200,13 +200,13 @@ wof:
     user: osm
     password:
 
-# A metatile is a .zip package of multiple tiles. Storing multiple, related 
+# A metatile is a .zip package of multiple tiles. Storing multiple, related
 # tiles together can be beneficial by reducing the number of writes to disk when
 # storing and loading them.
 metatile:
   # The metatile size setting has the following effects:
   #
-  #   - null or omitted entry: Individual tiles, one for each format, will be 
+  #   - null or omitted entry: Individual tiles, one for each format, will be
   #     saved on disk. This can be a good choice for local development use, or to 
   #     save files to be served directly from storage (i.e: without tapalcatl).
   #
@@ -218,7 +218,18 @@ metatile:
   #     area will be saved together, with all their formats. The filename of the
   #     tile will be based on the coordinate of the "512px" tile, but the zoom
   #     level used for styling will be one higher; that of the "256px" tiles.
+  #
+  #   - 4: A "1024px" tile, 4 "512px" tiles and 16 "256px" tiles covering the
+  #     same area.
   size: null
+
+  # if specified, the zoom levels to leave off the top of the metatile pyramid.
+  # for example, if the metatile size is specified at 4 and the start-zoom as 1,
+  # then the "1024px" tile will be omitted. if start-zoom is 2, then the
+  # "1024px" tile and all four "512px" tiles will be omitted.
+  #
+  # optional: defaults to zero.
+  start-zoom: 0
 
 # Configuration for where to store the tiles of interest set
 toi-store:

--- a/tests/test_mvt.py
+++ b/tests/test_mvt.py
@@ -32,7 +32,7 @@ class MapboxVectorTileTest(unittest.TestCase):
 
         post_process_data = {}
         buffer_cfg = {}
-        cut_coords = list()
+        cut_coords = [coord]
         if nominal_zoom > coord.zoom:
             cut_coords.extend(coord_children_range(coord, nominal_zoom))
 
@@ -44,8 +44,8 @@ class MapboxVectorTileTest(unittest.TestCase):
             coord, nominal_zoom, feature_layers, post_process_data, formats,
             unpadded_bounds, cut_coords, buffer_cfg, output_calc_mapping)
 
-        self.assertEqual(len(cut_coords) + 1, len(tiles))
-        return tiles, ([coord] + cut_coords)
+        self.assertEqual(len(cut_coords), len(tiles))
+        return tiles, cut_coords
 
     def _check_metatile(self, metatile_size):
         from mock import patch

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -1662,7 +1662,7 @@ def tilequeue_process_tile(cfg, peripherals, args):
     feature_layers = convert_source_data_to_feature_layers(
         source_rows, layer_data, unpadded_bounds, coord.zoom)
 
-    cut_coords = []
+    cut_coords = [coord]
     if nominal_zoom > coord.zoom:
         cut_coords.extend(coord_children_range(coord, nominal_zoom))
 

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -688,7 +688,8 @@ def tilequeue_process(cfg, peripherals):
 
     data_fetch = DataFetch(
         feature_fetcher, tile_input_queue, sql_data_fetch_queue, io_pool,
-        tile_proc_logger, stats_handler, cfg.metatile_zoom, cfg.max_zoom)
+        tile_proc_logger, stats_handler, cfg.metatile_zoom, cfg.max_zoom,
+        cfg.metatile_start_zoom)
 
     data_processor = ProcessAndFormatData(
         post_process_data, formats, sql_data_fetch_queue, processor_queue,

--- a/tilequeue/config.py
+++ b/tilequeue/config.py
@@ -117,6 +117,7 @@ class Configuration(object):
 
         self.metatile_size = self._cfg('metatile size')
         self.metatile_zoom = metatile_zoom_from_size(self.metatile_size)
+        self.metatile_start_zoom = self._cfg('metatile start-zoom')
 
         self.max_zoom_with_changes = self._cfg('tiles max-zoom-with-changes')
         assert self.max_zoom_with_changes > self.metatile_zoom
@@ -244,6 +245,7 @@ def default_yml_config():
         },
         'metatile': {
             'size': None,
+            'start-zoom': 0,
         },
         'queue_buffer_size': {
             'sql': None,

--- a/tilequeue/tile.py
+++ b/tilequeue/tile.py
@@ -284,17 +284,27 @@ def coord_children(coord):
 
 def coord_children_range(coord, zoom_until):
     assert zoom_until > coord.zoom
+    for child in coord_children_subrange(coord, coord.zoom + 1, zoom_until):
+        yield child
+
+
+def coord_children_subrange(coord, zoom_start, zoom_until):
+    assert zoom_start >= coord.zoom
+    assert zoom_until >= coord.zoom
     children_to_process = [coord]
+    if zoom_start <= coord.zoom:
+        yield coord
     cur_zoom = coord.zoom
     while cur_zoom < zoom_until:
         next_children = []
+        cur_zoom += 1
         for child_to_process in children_to_process:
             children = coord_children(child_to_process)
             for child in children:
-                yield child
+                if zoom_start <= cur_zoom:
+                    yield child
                 next_children.append(child)
         children_to_process = next_children
-        cur_zoom += 1
 
 
 tolerances = [6378137 * 2 * math.pi / (2 ** (zoom + 8)) for zoom in range(22)]

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -347,7 +347,7 @@ class DataFetch(object):
         # and its four children to cut from it. at zoom 15, this may
         # also include a whole bunch of other children below the max
         # zoom.
-        cut_coords = list()
+        cut_coords = [coord]
         if nominal_zoom > coord.zoom:
             cut_coords.extend(coord_children_range(coord, nominal_zoom))
 

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -11,7 +11,7 @@ from tilequeue.process import process_coord
 from tilequeue.queue import JobProgressException
 from tilequeue.queue.message import QueueHandle
 from tilequeue.store import write_tile_if_changed
-from tilequeue.tile import coord_children_range
+from tilequeue.tile import coord_children_subrange
 from tilequeue.tile import coord_to_mercator_bounds
 from tilequeue.tile import serialize_coord
 from tilequeue.utils import convert_seconds_to_millis
@@ -285,7 +285,8 @@ class DataFetch(object):
 
     def __init__(
             self, fetcher, input_queue, output_queue, io_pool,
-            tile_proc_logger, stats_handler, metatile_zoom, max_zoom):
+            tile_proc_logger, stats_handler, metatile_zoom, max_zoom,
+            metatile_start_zoom=0):
         self.fetcher = fetcher
         self.input_queue = input_queue
         self.output_queue = output_queue
@@ -294,6 +295,7 @@ class DataFetch(object):
         self.stats_handler = stats_handler
         self.metatile_zoom = metatile_zoom
         self.max_zoom = max_zoom
+        self.metatile_start_zoom = metatile_start_zoom
 
     def __call__(self, stop):
         saw_sentinel = False
@@ -334,6 +336,7 @@ class DataFetch(object):
 
     def _fetch(self, fetch, coord, metadata):
         nominal_zoom = coord.zoom + self.metatile_zoom
+        start_zoom = coord.zoom + self.metatile_start_zoom
         unpadded_bounds = coord_to_mercator_bounds(coord)
 
         start = time.time()
@@ -347,9 +350,8 @@ class DataFetch(object):
         # and its four children to cut from it. at zoom 15, this may
         # also include a whole bunch of other children below the max
         # zoom.
-        cut_coords = [coord]
-        if nominal_zoom > coord.zoom:
-            cut_coords.extend(coord_children_range(coord, nominal_zoom))
+        cut_coords = list(
+            coord_children_subrange(coord, start_zoom, nominal_zoom))
 
         return dict(
             metadata=metadata,


### PR DESCRIPTION
Add a configurable option to lop the top off the metatile pyramid. E.g: if we're using `metatile.size: 4` to generate 4x4 metatiles, then `metatile.start-zoom: 1` should mean we don't generate the "1024px" tile.

Note that this changes the meaning of `process_coord` - it used to generate a tile for `coord` and each of `cut_coords`, but now only generates a tile for each of `cut_coords`. This change in meaning (and the same for `format_tile`) requires a corresponding change in `tileserver`.