### PR TITLE
Miscellaneous RAWR tile fixes

### DIFF
--- a/tests/queue/test_msg.py
+++ b/tests/queue/test_msg.py
@@ -133,8 +133,8 @@ class MultipleMessageTrackerTest(unittest.TestCase):
         parent_tile = deserialize_coord('1/1/1')
         self._assert_track_done(coords, queue_handle, parent_tile)
 
-    def _assert_track_done(self, coords, queue_handle, expected_parent_tile):
-        coord_handles = self.tracker.track(queue_handle, coords)
+    def _assert_track_done(self, coords, queue_handle, parent_tile):
+        coord_handles = self.tracker.track(queue_handle, coords, parent_tile)
         self.assertEqual(len(coords), len(coord_handles))
 
         # all intermediate coords should not result in a done message.
@@ -146,4 +146,4 @@ class MultipleMessageTrackerTest(unittest.TestCase):
         track_result = self.tracker.done(coord_handles[-1])
         self.assertIs(queue_handle, track_result.queue_handle)
         self.assertTrue(track_result.all_done)
-        self.assertEqual(expected_parent_tile, track_result.parent_tile)
+        self.assertEqual(parent_tile, track_result.parent_tile)

--- a/tests/queue/test_msg.py
+++ b/tests/queue/test_msg.py
@@ -147,3 +147,14 @@ class MultipleMessageTrackerTest(unittest.TestCase):
         self.assertIs(queue_handle, track_result.queue_handle)
         self.assertTrue(track_result.all_done)
         self.assertEqual(parent_tile, track_result.parent_tile)
+
+    def test_track_and_done_asserts_on_duplicates(self):
+        from tilequeue.tile import deserialize_coord
+        from tilequeue.queue.message import QueueHandle
+        queue_id = 1
+        queue_handle = QueueHandle(queue_id, 'handle')
+        coords = map(deserialize_coord, ('2/2/2', '2/2/2'))
+        parent_tile = deserialize_coord('1/1/1')
+
+        with self.assertRaises(AssertionError):
+            self.tracker.track(queue_handle, coords, parent_tile)

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -684,7 +684,7 @@ def tilequeue_process(cfg, peripherals):
     tile_queue_reader = TileQueueReader(
         queue_mapper, msg_marshaller, msg_tracker, tile_input_queue,
         tile_proc_logger, stats_handler, thread_tile_queue_reader_stop,
-        cfg.max_zoom)
+        cfg.max_zoom, cfg.group_by_zoom)
 
     data_fetch = DataFetch(
         feature_fetcher, tile_input_queue, sql_data_fetch_queue, io_pool,

--- a/tilequeue/config.py
+++ b/tilequeue/config.py
@@ -130,6 +130,8 @@ class Configuration(object):
         self.tile_traffic_log_path = self._cfg(
             'toi-prune tile-traffic-log-path')
 
+        self.group_by_zoom = self.subtree('rawr group-zoom')
+
     def _cfg(self, yamlkeys_str):
         yamlkeys = yamlkeys_str.split()
         yamlval = self.yml

--- a/tilequeue/queue/message.py
+++ b/tilequeue/queue/message.py
@@ -1,5 +1,4 @@
 from collections import namedtuple
-from tilequeue.metatile import common_parent
 from tilequeue.tile import deserialize_coord
 from tilequeue.tile import serialize_coord
 import threading

--- a/tilequeue/queue/message.py
+++ b/tilequeue/queue/message.py
@@ -112,9 +112,12 @@ class MultipleMessagesPerCoordTracker(object):
         # running out of memory if a coordinate never completes
         self.lock = threading.Lock()
 
-    def track(self, queue_handle, coords):
-        parent_tile = None
-        is_pyramid = False
+    def track(self, queue_handle, coords, parent_tile=None):
+        is_pyramid = len(coords) > 1
+        if is_pyramid:
+            assert parent_tile is not None, "parent tile was not provided, " \
+                "but is required for tracking pyramids of tiles."
+
         with self.lock:
             # rely on the queue handle token as the mapping key
             queue_handle_id = queue_handle.handle
@@ -123,15 +126,9 @@ class MultipleMessagesPerCoordTracker(object):
             coord_ids = set()
             coord_handles = []
             for coord in coords:
-
-                if parent_tile is None:
-                    parent_tile = coord
-                else:
-                    parent_tile = common_parent(parent_tile, coord)
-                    is_pyramid = True
-
                 coord_id = (int(coord.zoom), int(coord.column), int(coord.row))
                 coord_handle = (coord_id, queue_handle_id)
+                assert coord_id not in coord_ids
                 coord_ids.add(coord_id)
                 coord_handles.append(coord_handle)
 
@@ -149,22 +146,20 @@ class MultipleMessagesPerCoordTracker(object):
 
         with self.lock:
             coord_id, queue_handle_id = coord_handle
+
             coord_ids = self.coord_ids_map.get(queue_handle_id)
-            if coord_ids is None:
-                self.msg_tracker_logger.unknown_queue_handle_id(
-                    coord_id, queue_handle_id)
-
-            else:
-                if coord_id not in coord_ids:
-                    self.msg_tracker_logger.unknown_coord_id(
-                        coord_id, queue_handle_id)
-                else:
-                    coord_ids.remove(coord_id)
-
             queue_handle = self.queue_handle_map.get(queue_handle_id)
-            if queue_handle is None:
+
+            if queue_handle is None or coord_ids is None:
                 self.msg_tracker_logger.unknown_queue_handle_id(
                     coord_id, queue_handle_id)
+                return MessageDoneResult(None, False, None)
+
+            if coord_id not in coord_ids:
+                self.msg_tracker_logger.unknown_coord_id(
+                    coord_id, queue_handle_id)
+            else:
+                coord_ids.remove(coord_id)
 
             if not coord_ids:
                 # we're done with all coordinates for the queue message
@@ -176,7 +171,7 @@ class MultipleMessagesPerCoordTracker(object):
                     del self.coord_ids_map[queue_handle_id]
                 except KeyError:
                     pass
-                all_done = queue_handle is not None
+                all_done = True
                 parent_tile = self.pyramid_map.pop(queue_handle_id, None)
 
         return MessageDoneResult(queue_handle, all_done, parent_tile)

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -250,11 +250,18 @@ class TileQueueReader(object):
 
                     all_coords_data.append(data)
 
-                coord_input_spec = all_coords_data, top_tile
-                msg = "group of %d tiles below %s" \
-                      % (len(all_coords_data), serialize_coord(top_tile))
-                if self.output(msg, coord_input_spec):
-                    break
+                if top_tile is None:
+                    # then we must have rejected all the coordinates, which
+                    # should mean that the whole tile has been ACKed and done
+                    # already. and there's nothing else to do.
+                    assert len(all_coords_data) == 0
+
+                else:
+                    coord_input_spec = all_coords_data, top_tile
+                    msg = "group of %d tiles below %s" \
+                          % (len(all_coords_data), serialize_coord(top_tile))
+                    if self.output(msg, coord_input_spec):
+                        break
 
         for _, tile_queue in self.queue_mapper.queues_in_priority_order():
             tile_queue.close()

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -114,7 +114,7 @@ def _ack_coord_handle(
             stacktrace = format_stacktrace_one_line()
             tile_proc_logger.error_job_done(
                 'tile_queue.job_done', e, stacktrace,
-                queue_handle, coord, parent_tile,
+                coord, parent_tile,
             )
             return queue_handle, e
 
@@ -132,12 +132,12 @@ def _ack_coord_handle(
             tile_queue.job_progress(queue_handle.handle)
         except Exception as e:
             stacktrace = format_stacktrace_one_line()
-            err_details = None
+            err_details = {"queue_handle": queue_handle.handle}
             if isinstance(e, JobProgressException):
                 err_details = e.err_details
             tile_proc_logger.error_job_progress(
                 'tile_queue.job_progress', e, stacktrace,
-                queue_handle, coord, parent_tile, err_details,
+                coord, parent_tile, err_details,
             )
             return queue_handle, e
 

--- a/tilequeue/worker.py
+++ b/tilequeue/worker.py
@@ -217,6 +217,12 @@ class TileQueueReader(object):
                 if not coords:
                     continue
 
+                # check for duplicate coordinates - for the message tracking to
+                # work, we assume that coordinates are unique, as we use them
+                # as keys in a dict. (plus, it doesn't make a lot of sense to
+                # render the coordinate twice in the same job anyway).
+                coords = list(set(coords))
+
                 parent_tile = self._parent(coords)
 
                 queue_handle = QueueHandle(queue_id, msg_handle.handle)


### PR DESCRIPTION
Various random issues that came up while running the RAWR tiles TOI through dev at 4x4 metatile size:

1. Because our TOI metatile size was 2x2 and therefore mismatched with the 4x4 metatile size of jobs we were rendering, some jobs rejected all the tiles in them (because they were at z15, which doesn't exist for 4x4 - it stops at z14). This was causing exceptions to be thrown when trying to access properties of `top_tile`, which was `None`. This change discards those jobs before they are sent for rendering, which is safe because the message tracker will have already ACKed them when the final coordinate was rejected.
2. Possibly also related to metatile size mismatch; we were getting duplicate coordinates in the job. This broke the message tracker, which uses coordinates as unique keys. This change makes the coordinates unique and also asserts that tracker keys are unique.
3. Fix the signature of `logger.error_job_*` to match what it was being called with.