### PR TITLE
Configurable up-zooming of tiles from Redshift

### DIFF
--- a/tests/test_tile.py
+++ b/tests/test_tile.py
@@ -219,3 +219,24 @@ class CoordIntZoomTest(unittest.TestCase):
             exp_int = coord_marshall_int(parent_coord)
             act_int = coord_int_zoom_up(coord_int)
             self.assertEquals(exp_int, act_int)
+
+
+class TestMetatileZoom(unittest.TestCase):
+
+    def test_zoom_from_size(self):
+        from tilequeue.tile import metatile_zoom_from_size as func
+        self.assertEqual(0, func(None))
+        self.assertEqual(0, func(1))
+        self.assertEqual(1, func(2))
+        self.assertEqual(2, func(4))
+
+        with self.assertRaises(AssertionError):
+            func(3)
+
+    def test_zoom_from_str(self):
+        from tilequeue.tile import metatile_zoom_from_str as func
+        self.assertEqual(0, func(None))
+        self.assertEqual(0, func(""))
+        self.assertEqual(0, func("256"))
+        self.assertEqual(1, func("512"))
+        self.assertEqual(2, func("1024"))

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -25,6 +25,7 @@ from tilequeue.tile import coord_to_mercator_bounds
 from tilequeue.tile import coord_unmarshall_int
 from tilequeue.tile import create_coord
 from tilequeue.tile import deserialize_coord
+from tilequeue.tile import metatile_zoom_from_str
 from tilequeue.tile import parse_expired_coord_string
 from tilequeue.tile import seed_tiles
 from tilequeue.tile import serialize_coord
@@ -1218,14 +1219,27 @@ def tilequeue_prune_tiles_of_interest(cfg, peripherals):
             ))
             for (x, y, z, tile_size, count) in cur:
                 coord = create_coord(x, y, z)
-                coord_int = coord_marshall_int(coord)
 
-                if not tile_size or tile_size == '256':
-                    # "uplift" a tile that is not explicitly a '512' size tile
-                    coord_int = coord_int_zoom_up(coord_int)
+                try:
+                    tile_zoom_offset = metatile_zoom_from_str(tile_size) - \
+                                       cfg.metatile_zoom
+                except AssertionError:
+                    # we don't want bogus data to kill the whole process, but
+                    # it's helpful to have a warning. we'll just skip the bad
+                    # row and continue.
+                    logger.warning('Tile size %r is bogus. Should be None, '
+                                   '256, 512 or 1024' % (tile_size,))
+                    continue
+
+                if tile_zoom_offset:
+                    # if the tile is not the same size as the metatile, then we
+                    # need to offset the zoom to make sure we enqueue the job
+                    # which results in this coordinate being rendered.
+                    coord = coord.zoomBy(tile_zoom_offset).container()
 
                 # Sum the counts from the 256 and 512 tile requests into the
                 # slot for the 512 tile.
+                coord_int = coord_marshall_int(coord)
                 redshift_results[coord_int] += count
 
     logger.info('Fetching tiles recently requested ... done. %s found',

--- a/tilequeue/tile.py
+++ b/tilequeue/tile.py
@@ -377,3 +377,17 @@ def metatile_zoom_from_size(metatile_size):
             "Metatile size must be a power of two."
 
     return metatile_zoom
+
+
+def metatile_zoom_from_str(tile_size):
+    if not tile_size:
+        # missing tile size indicates the default, which is currently 256px.
+        # this is a zoom offset of 0.
+        return 0
+
+    # calculate the number of standard 256px tiles across this tile is.
+    size = int(tile_size) / 256
+
+    # and convert that to the zoom level offset that would create a metatile
+    # of that size.
+    return metatile_zoom_from_size(size)


### PR DESCRIPTION
This changes the TOI gardener/pruner to parse the tile size and use the configured metatile size to up-zoom access logs to the metatile they're part of.