### PR TITLE
Filter to different queue based on TOI membership.

### DIFF
--- a/tilequeue/queue/mapper.py
+++ b/tilequeue/queue/mapper.py
@@ -33,25 +33,43 @@ class SingleQueueMapper(object):
 # pass in None for start/end to add queues that are read from
 # but that aren't considered for enqueueing directly when dispatching
 # eg a high priority queue
-ZoomRangeQueueSpec = namedtuple('ZoomRangeCfgSpec',
-                                'start end queue_name queue group_by_zoom')
+ZoomRangeQueueSpec = namedtuple(
+    'ZoomRangeCfgSpec',
+    'start end queue_name queue group_by_zoom in_toi')
+# set the last parameter to default to None
+ZoomRangeQueueSpec.__new__.__defaults__ = (None,)
 
 # what the mapper uses internally
 # these are what will get checked for queue dispatch
-ZoomRangeQueueItem = namedtuple('ZoomRangeItem',
-                                'start end queue_id group_by_zoom')
+ZoomRangeQueueItem = namedtuple(
+    'ZoomRangeItem',
+    'start end queue_id group_by_zoom in_toi')
 
 
 class ZoomRangeAndZoomGroupQueueMapper(object):
 
-    def __init__(self, zoom_range_specs):
+    def __init__(self, zoom_range_specs, toi=None):
         # NOTE: zoom_range_specs should be passed in priority order
         self.zoom_range_items = []
         self.queue_mapping = []
         for i, zrs in enumerate(zoom_range_specs):
             self.queue_mapping.append(zrs.queue)
-            zri = ZoomRangeQueueItem(zrs.start, zrs.end, i, zrs.group_by_zoom)
+            zri = ZoomRangeQueueItem(zrs.start, zrs.end, i, zrs.group_by_zoom,
+                                     zrs.in_toi)
             self.zoom_range_items.append(zri)
+
+        # check that if any queue item uses the TOI as part of the check, then
+        # we have been passed a TOI object to check it against.
+        uses_toi = any(zri.in_toi is not None for zri in self.zoom_range_items)
+        if uses_toi:
+            assert toi is not None, "If any zoom range item depends on " \
+                "whether a coordinate is in the TOI then a TOI object must " \
+                "be provided, but there is only None."
+
+            # NOTE: this is a one-off operation, so for long-running processes,
+            # we must either re-create the mapper object, or periodically
+            # refresh the TOI set.
+            self.toi_set = toi.fetch_tiles_of_interest()
 
     def group(self, coords):
         """return CoordGroups that can be used to send to queues
@@ -69,7 +87,9 @@ class ZoomRangeAndZoomGroupQueueMapper(object):
         # first group the coordinates based on their queue
         for coord in coords:
             for i, zri in enumerate(self.zoom_range_items):
-                if zri.start <= coord.zoom < zri.end:
+                toi_match = zri.in_toi is None or \
+                            (coord in self.toi_set) == zri.in_toi
+                if zri.start <= coord.zoom < zri.end and toi_match:
                     groups[i].append(coord)
                     break
 


### PR DESCRIPTION
This adds the ability to filter to a different queue depending on whether the coordinate is part of the TOI or not. This means that we can configure different setups, such as:

1. Queue filter by zoom, intersect on TOI: Current configuration, renders the TOI only.
2. Queue filter by TOI, intersect all tiles: "Global build" configuration, renders all tiles, but can send TOI tiles to a higher priority queue.

The configuration should allow flexible priorities, for example whether all TOI comes before all non-TOI, or whether they're interleaved by zoom.