### PR TITLE
Add route modifiers to network property.

### DIFF
--- a/tests/test_query_common.py
+++ b/tests/test_query_common.py
@@ -105,3 +105,14 @@ class TestCommon(unittest.TestCase):
 
         self.assertEquals(['road', 'US:I:Business', '70'],
                           layer_props.get('mz_networks'))
+
+    def test_business_not_at_end(self):
+        # check that, if the network contains 'Business', but it's not at the
+        # end, then we still don't append it.
+
+        layer_props = self._route_layer_properties(dict(
+            type='route', route='road', network='US:I:Business:Loop', ref='70',
+            modifier='business'))
+
+        self.assertEquals(['road', 'US:I:Business:Loop', '70'],
+                          layer_props.get('mz_networks'))

--- a/tilequeue/query/common.py
+++ b/tilequeue/query/common.py
@@ -408,9 +408,10 @@ def layer_properties(fid, shape, props, layer_name, zoom, osm):
                 us_network = network.startswith('US:')
                 us_route_modifier = modifier in _US_ROUTE_MODIFIERS
                 # don't want to add the suffix if it's already there.
-                needs_suffix = not network.endswith(':' + modifier)
+                suffix = ':' + modifier
+                needs_suffix = suffix not in network
                 if us_network and us_route_modifier and needs_suffix:
-                    network += ':' + modifier
+                    network += suffix
 
             if route and (network or ref):
                 mz_networks.extend([route, network, ref])


### PR DESCRIPTION
Sometimes there are additional `modifier` tags on route relations which alter the interpretation of the route, for example; local business or spur sections of the route. [We would prefer that these are part of the network property](https://github.com/tilezen/vector-datasource/issues/1387), which they often already are.

This modifies the tags during the query process and tests the expected transform. There will be a follow-up PR to `vector-datasource` to add integration tests and an equivalent transform to the SQL.

Connects to https://github.com/tilezen/vector-datasource/issues/1387.