### PR TITLE
Use nominal zoom in batch process.

### DIFF
--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -2015,8 +2015,8 @@ def tilequeue_batch_process(cfg, args):
                 cut_coords.extend(coord_children_range(coord, nominal_zoom))
 
             formatted_tiles, extra_data = process_coord(
-                coord, coord.zoom, feature_layers, post_process_data, formats,
-                unpadded_bounds, cut_coords, cfg.buffer_cfg,
+                coord, nominal_zoom, feature_layers, post_process_data,
+                formats, unpadded_bounds, cut_coords, cfg.buffer_cfg,
                 output_calc_mapping
             )
 


### PR DESCRIPTION
Batch process was calling `process_coord` with the `coord.zoom` rather than the nominal zoom, meaning that all tiles were 4096 in size, and also had lower levels of detail than intended.