### PR TITLE
fix crash on using the single queue type

### DIFF
--- a/tilequeue/queue/message.py
+++ b/tilequeue/queue/message.py
@@ -82,7 +82,7 @@ class SingleMessagePerCoordTracker(object):
     one-to-one mapping between queue handles and coordinates
     """
 
-    def track(self, queue_handle, coords):
+    def track(self, queue_handle, coords, parent_tile=None):
         assert len(coords) == 1
         return [queue_handle]
 


### PR DESCRIPTION
The single and multiple message per coord tracker queues are used
interchangeable on a config value, but the methods have not
the same count of arguments. This commit fixes the resulting crash
by adding the missing, unused parameter to the track function
of the SingleMessagePerCoordTracker class