### PR TITLE
sample config note explaining why md5 hash prefix is added for s3

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -50,6 +50,12 @@ store:
   type: s3 # Can also be `directory`, which would dump the tiles to disk.
   name: <s3 bucket/tile directory name>
   # The following store properties are s3 specific.
+  # NOTE: for s3 storage an additonal non configurable hash prefix is added
+  # that tapalcatl uses. You can manually remove this from the code if you want
+  # to directly access cached tiles in s3. But s3 storage is really meant to
+  # have tapalcatl in front of it with zipped tiles because s3 pricing
+  # per get request is uneconomical with raw tiles since the file size
+  # is very small and a large amount are requested when viewing a map.
   path: osm
   reduced-redundancy: true
   date-prefix: 19851026


### PR DESCRIPTION
Adds a note to the sample config explaining why the md5 hash prefix is added because of tapalcatl.

I was puzzled at first why there was the additional prefix in the s3 path when testing out tilequeue for the first time so I thought a note might help.