### PR TITLE
Add new source for tilezen.org.

### DIFF
--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -242,6 +242,8 @@ def lookup_source(source):
         result = Source('shp', source)
     elif source == 'whosonfirst.mapzen.com':
         result = Source('wof', source)
+    elif source == 'tilezen.org':
+        result = Source('shp', source)
 
     return result
 


### PR DESCRIPTION
The source for the `buffered_land` changed to `tilezen.org`, which requires that tilequeue understands what that means (this is probably a design flaw / unnecessary coupling that we should fix). This PR adds that.

Connects to https://github.com/tilezen/vector-datasource/issues/1482 and https://github.com/tilezen/raw_tiles/pull/20.