### PR TITLE
Use boto3 for tile store

### DIFF
--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -69,7 +69,7 @@ class TestStoreKey(unittest.TestCase):
         layer = 'all'
         tile_key = s3_tile_key(date_str, path, layer, coord,
                                json_format.extension)
-        self.assertEqual(tile_key, '/20160121/b707d/osm/all/8/72/105.json')
+        self.assertEqual(tile_key, '20160121/b707d/osm/all/8/72/105.json')
 
     def test_no_path(self):
         from tilequeue.store import s3_tile_key
@@ -81,7 +81,7 @@ class TestStoreKey(unittest.TestCase):
         layer = 'all'
         tile_key = s3_tile_key(date_str, path, layer, coord,
                                json_format.extension)
-        self.assertEqual(tile_key, '/20160121/cfc61/all/8/72/105.json')
+        self.assertEqual(tile_key, '20160121/cfc61/all/8/72/105.json')
 
 
 class WriteTileIfChangedTest(unittest.TestCase):

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -1979,7 +1979,8 @@ def tilequeue_batch_enqueue(cfg, args):
     logger = make_logger(cfg, 'batch_enqueue')
 
     import boto3
-    client = boto3.client('batch', region_name='us-east-1')
+    region_name = os.environ.get('AWS_DEFAULT_REGION', 'us-east-1')
+    client = boto3.client('batch', region_name=region_name)
 
     logger.info('Batch enqueue ...')
 

--- a/tilequeue/store.py
+++ b/tilequeue/store.py
@@ -1,7 +1,7 @@
 # define locations to store the rendered data
 
-from boto import connect_s3
-from boto.s3.bucket import Bucket
+import boto3
+from botocore.exceptions import ClientError
 from builtins import range
 from future.utils import raise_from
 import md5
@@ -12,6 +12,7 @@ from tilequeue.format import zip_format
 import random
 import threading
 import time
+from cStringIO import StringIO
 
 
 def calc_hash(s):
@@ -96,9 +97,10 @@ def _backoff_and_retry(ExceptionType, num_tries=5, retry_factor=2,
 class S3(object):
 
     def __init__(
-            self, bucket, date_prefix, path, reduced_redundancy,
-            delete_retry_interval, logger):
-        self.bucket = bucket
+            self, s3_client, bucket_name, date_prefix, path,
+            reduced_redundancy, delete_retry_interval, logger):
+        self.s3_client = s3_client
+        self.bucket_name = bucket_name
         self.date_prefix = date_prefix
         self.path = path
         self.reduced_redundancy = reduced_redundancy
@@ -108,15 +110,20 @@ class S3(object):
     def write_tile(self, tile_data, coord, format, layer):
         key_name = s3_tile_key(
             self.date_prefix, self.path, layer, coord, format.extension)
-        key = self.bucket.new_key(key_name)
+
+        storage_class = 'STANDARD'
+        if self.reduced_redundancy:
+            storage_class = 'REDUCED_REDUNDANCY'
 
         @_backoff_and_retry(Exception, logger=self.logger)
         def write_to_s3():
-            key.set_contents_from_string(
-                tile_data,
-                headers={'Content-Type': format.mimetype},
-                policy='public-read',
-                reduced_redundancy=self.reduced_redundancy,
+            self.s3_client.put_object(
+                Bucket=self.bucket_name,
+                Key=key_name,
+                Body=tile_data,
+                ContentType=format.mimetype,
+                ACL='public-read',
+                StorageClass=storage_class,
             )
 
         write_to_s3()
@@ -124,11 +131,17 @@ class S3(object):
     def read_tile(self, coord, format, layer):
         key_name = s3_tile_key(
             self.date_prefix, self.path, layer, coord, format.extension)
-        key = self.bucket.get_key(key_name)
-        if key is None:
-            return None
-        tile_data = key.get_contents_as_string()
-        return tile_data
+
+        try:
+            io = StringIO()
+            self.s3_client.download_fileobj(self.bucket_name, key_name, io)
+            return io.bytes()
+
+        except ClientError as e:
+            if e.response['Error']['Code'] != '404':
+                raise
+
+        return None
 
     def delete_tiles(self, coords, format, layer):
         key_names = [
@@ -138,22 +151,31 @@ class S3(object):
         ]
 
         num_deleted = 0
-        while key_names:
-            del_result = self.bucket.delete_keys(key_names)
-            num_deleted += len(del_result.deleted)
+        chunk_size = 1000
+        for idx in xrange(0, len(key_names), chunk_size):
+            chunk = key_names[idx:idx+chunk_size]
 
-            key_names = []
-            for error in del_result.errors:
-                # retry on internal error. documentation implies that the only
-                # possible two errors are AccessDenied and InternalError.
-                # retrying when access denied seems unlikely to work, but an
-                # internal error might be transient.
-                if error.code == 'InternalError':
-                    key_names.append(error.key)
+            while chunk:
+                objects = [dict(Key=k) for k in chunk]
+                del_result = self.s3_client.delete_objects(
+                    Bucket=self.bucket_name,
+                    Delete=dict(Objects=objects),
+                )
+                num_deleted += len(del_result['Deleted'])
 
-            # pause a bit to give transient errors a chance to clear.
-            if key_names:
-                time.sleep(self.delete_retry_interval)
+                chunk = []
+                for error in del_result['Errors']:
+                    # retry on internal error. documentation implies that the
+                    # only possible two errors are AccessDenied and
+                    # InternalError. retrying when access denied seems
+                    # unlikely to work, but an internal error might be
+                    # transient.
+                    if error['Code'] == 'InternalError':
+                        chunk.append(error['Key'])
+
+                # pause a bit to give transient errors a chance to clear.
+                if chunk:
+                    time.sleep(self.delete_retry_interval)
 
         # make sure that we deleted all the tiles - this seems like the
         # expected behaviour from the calling code.
@@ -164,11 +186,17 @@ class S3(object):
 
     def list_tiles(self, format, layer):
         ext = '.' + format.extension
-        for key_obj in self.bucket.list(prefix=self.date_prefix):
-            key = key_obj.key
-            coord = parse_coordinate_from_path(key, ext, layer)
-            if coord:
-                yield coord
+        paginator = self.s3_client.get_paginator('list_objects_v2')
+        page_iter = paginator.paginate(
+            Bucket=self.bucket_name,
+            Prefix=self.date_prefix
+        )
+        for page in page_iter:
+            for key_obj in page['Contents']:
+                key = key_obj['Key']
+                coord = parse_coordinate_from_path(key, ext, layer)
+                if coord:
+                    yield coord
 
 
 def make_dir_path(base_path, coord, layer):
@@ -352,12 +380,10 @@ class Memory(object):
 
 
 def make_s3_store(bucket_name,
-                  aws_access_key_id=None, aws_secret_access_key=None,
                   path='osm', reduced_redundancy=False, date_prefix='',
                   delete_retry_interval=60, logger=None):
-    conn = connect_s3(aws_access_key_id, aws_secret_access_key)
-    bucket = Bucket(conn, bucket_name)
-    s3_store = S3(bucket, date_prefix, path, reduced_redundancy,
+    s3 = boto3.resource('s3')
+    s3_store = S3(s3, bucket_name, date_prefix, path, reduced_redundancy,
                   delete_retry_interval, logger)
     return s3_store
 
@@ -409,13 +435,8 @@ def make_store(yml, credentials={}, logger=None):
         date_prefix = yml.get('date-prefix')
         delete_retry_interval = yml.get('delete-retry-interval')
 
-        assert credentials, 'S3 store configured, but no AWS credentials ' \
-            'provided. AWS credentials are required to use S3.'
-        aws_access_key_id = credentials.get('aws_access_key_id')
-        aws_secret_access_key = credentials.get('aws_secret_access_key')
-
         return make_s3_store(
-            bucket, aws_access_key_id, aws_secret_access_key, path=path,
+            bucket, path=path,
             reduced_redundancy=reduced_redundancy, date_prefix=date_prefix,
             delete_retry_interval=delete_retry_interval, logger=logger)
 


### PR DESCRIPTION
This changes the tile store implementation to use `boto3` rather than `boto` version 2. It also has a few random fixes, and extra configuration parameters.

* There's more verbose error logging for S3 errors. It now prints out the bucket and key, which should make tracking permissions errors down a bit easier.
* Use the region from the environment for Batch, if it's available. This means we're not hard-coded to `us-east-1` any more.
* Configurable object ACL. We use, `public-read` in Nextzen and this will be the default, but others may want `private`.