### PR TITLE
Fix incorrect method call on StringIO in store.

### DIFF
--- a/tilequeue/store.py
+++ b/tilequeue/store.py
@@ -144,7 +144,7 @@ class S3(object):
         try:
             io = StringIO()
             self.s3_client.download_fileobj(self.bucket_name, key_name, io)
-            return io.bytes()
+            return io.getvalue()
 
         except ClientError as e:
             if e.response['Error']['Code'] != '404':


### PR DESCRIPTION
D'oh! `StringIO` doesn't have a `.bytes()` function! I was probably thinking in Go when I wrote that. The effect was that Batch jobs would fail immediately when they attempted to fetch a tile which had already been rendered.