### PR TITLE
Configurable tile sizes with a metatile

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -204,7 +204,8 @@ wof:
 # tiles together can be beneficial by reducing the number of writes to disk when
 # storing and loading them.
 metatile:
-  # The metatile size setting has the following effects:
+  # The metatile size setting has the following effects by itself. But please
+  # note that the `tile-sizes` setting can affect this too!
   #
   #   - null or omitted entry: Individual tiles, one for each format, will be
   #     saved on disk. This can be a good choice for local development use, or to
@@ -230,6 +231,36 @@ metatile:
   #
   # optional: defaults to zero.
   start-zoom: 0
+
+  # if specificed, the tile sizes to render in each metatile. by default, this
+  # is all the sizes for the metatile, i.e: for `size=4`, then `tile-sizes`
+  # will default to [1024, 512, 256].
+  #
+  # if you don't need some of the sizes, then setting this to a reduced set
+  # can make your metatiles smaller. however, with a reduced set of sizes, the
+  # following special behaviour applies:
+  #
+  #  - at the maximum nominal zoom (see `tile.max-zoom-with-changes`), the
+  #    metatile will additionally contain all the smaller tiles at the same
+  #    nominal zoom. for example, if `tile-sizes` is [1024], `metatile.size`
+  #    is 4 and the `max-zoom-with-changes` is 16, then the highest zoom
+  #    metatile will be 14/x/y and will contain one 1024px tile, 2x2 512px
+  #    tiles and 4x4 256px tiles all at the `max-zoom-with-changes` nominal
+  #    zoom. this allows programs such as tapalcatl to serve smaller tiles
+  #    for a few zoom levels of "overzoom".
+  #
+  #  - at zoom zero, the metatile will additionally contain the same size of
+  #    tile at lower nominal and coordinate zooms. for example, if the
+  #    `tile-sizes` is [512, 256] and the metatile size is 8, then in addition
+  #    to the 512px and 256px tiles at nominal zoom 3, the tile will also
+  #    contain 512px tiles at nominal zooms 2 and 1. (because the 512px tile
+  #    at nominal zoom 1 covers the whole world, there is no tile output at
+  #    nominal zoom 0).
+  #
+  # optional: default behaviour is all the tile sizes, as described in the
+  # `size` parameter description.
+  #
+  #tile-sizes: [512, 256]
 
 # Configuration for where to store the tiles of interest set
 toi-store:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -90,24 +90,28 @@ class TestMetatileConfiguration(unittest.TestCase):
         cfg = self._call_fut(config_dict)
         self.assertIsNone(cfg.metatile_size)
         self.assertEquals(cfg.metatile_zoom, 0)
+        self.assertEquals(cfg.tile_sizes, [256])
 
     def test_metatile_size_1(self):
         config_dict = dict(metatile=dict(size=1))
         cfg = self._call_fut(config_dict)
         self.assertEquals(cfg.metatile_size, 1)
         self.assertEquals(cfg.metatile_zoom, 0)
+        self.assertEquals(cfg.tile_sizes, [256])
 
     def test_metatile_size_2(self):
         config_dict = dict(metatile=dict(size=2))
         cfg = self._call_fut(config_dict)
         self.assertEquals(cfg.metatile_size, 2)
         self.assertEquals(cfg.metatile_zoom, 1)
+        self.assertEquals(cfg.tile_sizes, [512, 256])
 
     def test_metatile_size_4(self):
         config_dict = dict(metatile=dict(size=4))
         cfg = self._call_fut(config_dict)
         self.assertEquals(cfg.metatile_size, 4)
         self.assertEquals(cfg.metatile_zoom, 2)
+        self.assertEquals(cfg.tile_sizes, [1024, 512, 256])
 
     def test_max_zoom(self):
         config_dict = dict(metatile=dict(size=2))

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -603,6 +603,13 @@ def make_min_zoom_calc_mapping(process_yaml_cfg):
     return min_zoom_calc_mapping
 
 
+def calc_cut_coords(coord, nominal_zoom):
+    cut_coords = [coord]
+    if nominal_zoom > coord.zoom:
+        cut_coords.extend(coord_children_range(coord, nominal_zoom))
+    return cut_coords
+
+
 def tilequeue_process(cfg, peripherals):
     from tilequeue.log import JsonTileProcessingLogger
     logger = make_logger(cfg, 'process')
@@ -1718,10 +1725,7 @@ def tilequeue_process_tile(cfg, peripherals, args):
     feature_layers = convert_source_data_to_feature_layers(
         source_rows, layer_data, unpadded_bounds, coord.zoom)
 
-    cut_coords = [coord]
-    if nominal_zoom > coord.zoom:
-        cut_coords.extend(coord_children_range(coord, nominal_zoom))
-
+    cut_coords = calc_cut_coords(coord, nominal_zoom)
     formats = lookup_formats(cfg.output_formats)
     formatted_tiles, extra_data = process_coord(
         coord, coord.zoom, feature_layers, post_process_data, formats,
@@ -2162,10 +2166,7 @@ def tilequeue_meta_tile(cfg, args):
                 meta_tile_logger.tile_fetch_failed(e, parent, job_coord, coord)
                 continue
 
-            cut_coords = [coord]
-            if nominal_zoom > coord.zoom:
-                cut_coords.extend(coord_children_range(coord, nominal_zoom))
-
+            cut_coords = calc_cut_coords(coord, nominal_zoom)
             try:
                 formatted_tiles, extra_data = process_coord(
                     coord, nominal_zoom, feature_layers, post_process_data,
@@ -2288,10 +2289,7 @@ def tilequeue_meta_tile_low_zoom(cfg, args):
             meta_low_zoom_logger.fetch_failed(e, parent, coord)
             continue
 
-        cut_coords = [coord]
-        if nominal_zoom > coord.zoom:
-            cut_coords.extend(coord_children_range(coord, nominal_zoom))
-
+        cut_coords = calc_cut_coords(coord, nominal_zoom)
         try:
             formatted_tiles, extra_data = process_coord(
                 coord, nominal_zoom, feature_layers, post_process_data,

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -11,7 +11,6 @@ from tilequeue.config import make_config_from_argparse
 from tilequeue.format import lookup_format_by_extension
 from tilequeue.metro_extract import city_bounds
 from tilequeue.metro_extract import parse_metro_extract
-from tilequeue.process import convert_source_data_to_feature_layers
 from tilequeue.process import TileFetchFailed
 from tilequeue.process import TileProcessFailed
 from tilequeue.process import process
@@ -24,7 +23,6 @@ from tilequeue.tile import coord_children_range
 from tilequeue.tile import coord_int_zoom_up
 from tilequeue.tile import coord_is_valid
 from tilequeue.tile import coord_marshall_int
-from tilequeue.tile import coord_to_mercator_bounds
 from tilequeue.tile import coord_unmarshall_int
 from tilequeue.tile import create_coord
 from tilequeue.tile import deserialize_coord
@@ -1716,8 +1714,8 @@ def tilequeue_process_tile(cfg, peripherals, args):
     for fetch, _ in data_fetcher.fetch_tiles([dict(coord=coord)]):
         formatted_tiles, extra_data = process(
             coord, cfg.metatile_zoom, fetch, layer_data, post_process_data,
-            formats, cfg.buffer_cfg, output_calc_mapping)
-        process
+            formats, cfg.buffer_cfg, output_calc_mapping, cfg.max_zoom,
+            cfg.tile_sizes)
 
     # can think about making this configurable
     # but this is intended for debugging anyway
@@ -2147,7 +2145,7 @@ def tilequeue_meta_tile(cfg, args):
                 formatted_tiles, extra_data = process(
                     coord, cfg.metatile_zoom, fetch, layer_data,
                     post_process_data, formats, cfg.buffer_cfg,
-                    output_calc_mapping)
+                    output_calc_mapping, cfg.max_zoom, cfg.tile_sizes)
 
             except TileFetchFailed as e:
                 meta_tile_logger.tile_fetch_failed(
@@ -2262,7 +2260,8 @@ def tilequeue_meta_tile_low_zoom(cfg, args):
         try:
             formatted_tiles, extra_data = process(
                 coord, cfg.metatile_zoom, fetch, layer_data, post_process_data,
-                formats, cfg.buffer_cfg, output_calc_mapping)
+                formats, cfg.buffer_cfg, output_calc_mapping, cfg.max_zoom,
+                cfg.tile_sizes)
 
         except TileFetchFailed as e:
             meta_low_zoom_logger.fetch_failed(

--- a/tilequeue/config.py
+++ b/tilequeue/config.py
@@ -132,6 +132,11 @@ class Configuration(object):
 
         self.group_by_zoom = self.subtree('rawr group-zoom')
 
+        self.tile_sizes = self._cfg('metatile tile-sizes')
+        if self.tile_sizes is None:
+            self.tile_sizes = [256 * (1 << z) for z in
+                               reversed(xrange(0, self.metatile_zoom + 1))]
+
     def _cfg(self, yamlkeys_str):
         yamlkeys = yamlkeys_str.split()
         yamlval = self.yml
@@ -248,6 +253,7 @@ def default_yml_config():
         'metatile': {
             'size': None,
             'start-zoom': 0,
+            'tile-sizes': None,
         },
         'queue_buffer_size': {
             'sql': None,

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 from collections import defaultdict
 from collections import namedtuple
 from cStringIO import StringIO
@@ -595,35 +597,166 @@ class TileProcessFailed(RuntimeError):
         self.coord = coord
 
 
-def _calc_cut_coords(self, coord, nominal_zoom):
-    cut_coords = [coord]
-    if nominal_zoom > coord.zoom:
-        cut_coords.extend(coord_children_range(coord, nominal_zoom))
-    return cut_coords
+def _is_power_of_2(x):
+    """
+    Returns True if `x` is a power of 2.
+    """
+
+    # see:
+    # https://graphics.stanford.edu/~seander/bithacks.html#DetermineIfPowerOf2
+    return x != 0 and (x & (x - 1)) == 0
+
+
+def metatile_children_with_size(coord, metatile_zoom, nominal_zoom, tile_size):
+    """
+    Return a list of all the coords which are children of the input metatile
+    at `coord` with zoom `metatile_zoom` (i.e: 0 for a single tile metatile,
+    1 for 2x2, 2 for 4x4, etc...) with size `tile_size` corrected for the
+    `nominal_zoom`.
+
+    For example, in a single tile metatile, the `tile_size` must be 256 and the
+    returned list contains only `coord`.
+
+    For an 8x8 metatile (`metatile_zoom = 3`), requesting the 512px children
+    would give a list of the 4x4 512px children at `coord.zoom + 2` with
+    nominal zoom `nominal_zoom`.
+
+    Correcting for nominal zoom means that some tiles may have coordinate zooms
+    lower than they would otherwise be. For example, the 0/0/0 tile with
+    metatile zoom 3 (8x8 256px tiles) would have 4x4 512px tiles at coordinate
+    zoom 2 and nominal zoom 3. At nominal zoom 2, there would be 2x2 512px
+    tiles at coordinate zoom 1.
+    """
+
+    from tilequeue.tile import coord_children_subrange
+    from tilequeue.tile import metatile_zoom_from_size
+
+    assert tile_size >= 256
+    assert tile_size <= 256 * (1 << metatile_zoom)
+    assert _is_power_of_2(tile_size)
+
+    # delta is how many zoom levels _lower_ we want the child tiles, based on
+    # their tile size. 256px tiles are defined as being at nominal zoom, so
+    # delta = 0 for them.
+    delta = metatile_zoom_from_size(tile_size // 256)
+
+    zoom = nominal_zoom - delta
+
+    return list(coord_children_subrange(coord, zoom, zoom))
+
+
+def calculate_sizes_by_zoom(coord, metatile_zoom, cfg_tile_sizes, max_zoom):
+    """
+    Returns a map of nominal zoom to the list of tile sizes to generate at that
+    zoom.
+
+    This is because we want to generate different metatile contents at
+    different zoom levels. At the most detailed zoom level, we want to generate
+    the smallest tiles possible, as this allows "overzooming" by simply
+    extracting the smaller tiles. At the minimum zoom, we want to get as close
+    as we can to zero nominal zoom by using any "unused" space in the metatile
+    for larger tile sizes that we're not generating.
+
+    For example, with 1x1 metatiles, the tile size is always 256px, and the
+    function will return {coord.zoom: [256]}
+    """
+
+    from tilequeue.tile import metatile_zoom_from_size
+
+    tile_size_by_zoom = {}
+    nominal_zoom = coord.zoom + metatile_zoom
+
+    # check that the tile sizes are correct and within range.
+    for tile_size in cfg_tile_sizes:
+        assert tile_size >= 256
+        assert tile_size <= 256 * (1 << metatile_zoom)
+        assert _is_power_of_2(tile_size)
+
+    if nominal_zoom >= max_zoom:
+        # all the tile_sizes down to 256 at the nominal zoom.
+        tile_sizes = []
+        tile_sizes.extend(cfg_tile_sizes)
+
+        lowest_tile_size = min(tile_sizes)
+        while lowest_tile_size > 256:
+            lowest_tile_size //= 2
+            tile_sizes.append(lowest_tile_size)
+
+        tile_size_by_zoom[nominal_zoom] = tile_sizes
+
+    elif coord.zoom <= 0:
+        # the tile_sizes, plus max(tile_sizes) size at nominal zooms decreasing
+        # down to 0 (or as close as we can get)
+        tile_size_by_zoom[nominal_zoom] = cfg_tile_sizes
+
+        max_tile_size = max(cfg_tile_sizes)
+        max_tile_zoom = metatile_zoom_from_size(max_tile_size // 256)
+        assert max_tile_zoom <= metatile_zoom
+        for delta in range(0, metatile_zoom - max_tile_zoom):
+            z = nominal_zoom - (delta + 1)
+            tile_size_by_zoom[z] = [max_tile_size]
+
+    else:
+        # the tile_sizes at nominal zoom only.
+        tile_size_by_zoom[nominal_zoom] = cfg_tile_sizes
+
+    return tile_size_by_zoom
+
+
+def calculate_cut_coords_by_zoom(
+        coord, metatile_zoom, cfg_tile_sizes, max_zoom):
+    """
+    Returns a map of nominal zoom to the list of cut coordinates at that
+    nominal zoom.
+    """
+
+    tile_sizes_by_zoom = calculate_sizes_by_zoom(
+        coord, metatile_zoom, cfg_tile_sizes, max_zoom)
+
+    cut_coords_by_zoom = {}
+    for nominal_zoom, tile_sizes in tile_sizes_by_zoom.iteritems():
+        cut_coords = []
+        for tile_size in tile_sizes:
+            cut_coords.extend(metatile_children_with_size(
+                coord, metatile_zoom, nominal_zoom, tile_size))
+
+        cut_coords_by_zoom[nominal_zoom] = cut_coords
+
+    return cut_coords_by_zoom
 
 
 def process(coord, metatile_zoom, fetch, layer_data, post_process_data,
-            formats, buffer_cfg, output_calc_mapping):
-    nominal_zoom = coord.zoom + metatile_zoom
+            formats, buffer_cfg, output_calc_mapping, max_zoom,
+            cfg_tile_sizes):
     unpadded_bounds = coord_to_mercator_bounds(coord)
 
+    cut_coords_by_zoom = calculate_cut_coords_by_zoom(
+        coord, metatile_zoom, cfg_tile_sizes, max_zoom)
+    feature_layers_by_zoom = {}
+
     try:
-        source_rows = fetch(nominal_zoom, unpadded_bounds)
-        feature_layers = convert_source_data_to_feature_layers(
-            source_rows, layer_data, unpadded_bounds, coord.zoom)
+        for nominal_zoom, _ in cut_coords_by_zoom:
+            source_rows = fetch(nominal_zoom, unpadded_bounds)
+            feature_layers = convert_source_data_to_feature_layers(
+                source_rows, layer_data, unpadded_bounds, coord.zoom)
+            feature_layers_by_zoom[nominal_zoom] = feature_layers
     except Exception as e:
         raise TileFetchFailed(e, coord)
 
-    try:
-        cut_coords = _calc_cut_coords(coord, nominal_zoom)
+    all_formatted_tiles = []
+    all_extra_data = {}
 
-        formatted_tiles, extra_data = process_coord(
-            coord, nominal_zoom, feature_layers, post_process_data, formats,
-            unpadded_bounds, cut_coords, buffer_cfg, output_calc_mapping
-        )
-        return formatted_tiles, extra_data
+    try:
+        for nominal_zoom, cut_coords in cut_coords_by_zoom:
+            formatted_tiles, extra_data = process_coord(
+                coord, nominal_zoom, feature_layers, post_process_data,
+                formats, unpadded_bounds, cut_coords, buffer_cfg,
+                output_calc_mapping
+            )
+            all_formatted_tiles.extend(formatted_tiles)
+            all_extra_data.update(extra_data)
 
     except Exception as e:
         raise TileProcessFailed(e, coord)
 
-    return formatted_tiles, extra_data
+    return all_formatted_tiles, all_extra_data


### PR DESCRIPTION
The previous behaviour to generate all the tiles of different sizes within a metatile. That worked great while we were generating 512px and 256px tiles in a size 2 metatile. It kinda worked while we were generating 1024px, 512px and 256px tiles in a size 4 metatile. However, moving to a size 8 metatile means we're duplicating information across 4 different sizes of tile - two of which we don't use ever, and the last one we rarely use.

This change introduces configurable tile sizes within a metatile. For example, it's possible to specify just 256, just 512 or both. This will cut down on extra, unwanted data in metatiles.

There are some special cases to this:

## At maximum zoom

For maximum nominal zoom tiles, smaller tiles are always included even if not configured. This means that if the maximum nominal zoom is 16 and the configured `tile-sizes: [512]`, the metatile containing nominal zoom 16 (e.g: at zoom 13 for 8x8 metatiles) will contain both 512px and 256px tiles. This allows `tapalcatl` to treat the smaller tiles as "overzooms" for the larger tiles.

## At minimum zoom

For zoom zero tiles, unused "slots" in the metatile for larger tiles will be used by lower zoom tiles. For example, if the only configured tile size is 512px and the metatile size is 8x8, then we would expect the `0/0/0` metatile to contain the 4x4 `2/x/y` 512px tiles only. However, this means we don't have any tiles for requests at zoom levels 0 and 1. So we also render the **512px** tiles at lower nominal zooms to provide those.

Normally, a metatile would only contain tiles all at the same nominal zoom. This change breaks that, but means we don't have to add negative zoom tiles to the already complicated mental model of zooms, metatiles, nominal zooms, etc...

This last change fixes an issue with not generating zoom 0: #341.