### PR TITLE
Model batch jobs as aws batch array jobs

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -439,7 +439,12 @@ batch:
   retry-attempts: 5
   # check store if metatile already exists, and if so skip processing
   check-metatile-exists: true
-  # used when enqueueing batch array jobs, can be "low" or "high"
+  # used when enqueueing batch array jobs, the job-type can be "low" or "high"
+  # this affects the batch array jobs size
+  # low:  z7 coord represents all tiles at z7, z8, z9
+  # high: z7 coord represents all tiles at z10 equivalent
+  # when enqueueing low zoom metatiles, z0-9, set to "low"
+  # when enqueueing high zoom metatiles and rawr tiles, set to "high"
   job-type: <job-type>
   # optional override memory reserved for container when submiting job
   # NOTE: in megabytes

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -439,6 +439,8 @@ batch:
   retry-attempts: 5
   # check store if metatile already exists, and if so skip processing
   check-metatile-exists: true
+  # used when enqueueing batch array jobs, can be "low" or "high"
+  job-type: <job-type>
   # optional override memory reserved for container when submiting job
   # NOTE: in megabytes
   # https://docs.aws.amazon.com/batch/latest/APIReference/API_ContainerOverrides.html

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -142,3 +142,38 @@ class ZoomToQueueNameMapTest(unittest.TestCase):
         zoom = long(7)
         queue_name = get_queue(zoom)
         self.assertEqual(queue_name, 'q1')
+
+
+class BatchJobCoordTest(unittest.TestCase):
+
+    def test_low_zoom(self):
+        from tilequeue.command import get_batch_job_coords_low_zoom
+        from tilequeue.tile import deserialize_coord
+        coord = deserialize_coord('7/0/0')
+        coords = list(get_batch_job_coords_low_zoom(coord, 7, 10))
+        for c in coords:
+            self.assertTrue(7 <= c.zoom <= 9)
+        self.assertEqual(21, len(coords))
+
+    def test_high_zoom(self):
+        from tilequeue.command import get_batch_job_coords_high_zoom
+        from tilequeue.tile import deserialize_coord
+        coord = deserialize_coord('7/0/0')
+        coords = list(get_batch_job_coords_high_zoom(coord, 7, 10))
+        for c in coords:
+            self.assertTrue(c.zoom == 10)
+        self.assertEqual(64, len(coords))
+
+    def test_get_batch_job_coord_idx(self):
+        from tilequeue.command import get_batch_job_coord
+        from tilequeue.tile import deserialize_coord
+        coords = [deserialize_coord('10/1/1')]
+        self.assertIsNotNone(get_batch_job_coord(coords, 0))
+        self.assertIsNone(get_batch_job_coord(coords, -1))
+        self.assertIsNone(get_batch_job_coord(coords, 1))
+        import os
+        self.assertIsNone(get_batch_job_coord(coords))
+        os.environ['AWS_BATCH_JOB_ARRAY_INDEX'] = '0'
+        self.assertIsNotNone(get_batch_job_coord(coords))
+        os.environ['AWS_BATCH_JOB_ARRAY_INDEX'] = '1'
+        self.assertIsNone(get_batch_job_coord(coords))

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from collections import namedtuple
 from contextlib import closing
 from itertools import chain
+from itertools import islice
 from ModestMaps.Core import Coordinate
 from multiprocessing.pool import ThreadPool
 from random import randrange
@@ -19,6 +20,7 @@ from tilequeue.queue import make_sqs_queue
 from tilequeue.queue import make_visibility_manager
 from tilequeue.store import make_store
 from tilequeue.tile import coord_children_range
+from tilequeue.tile import coord_children_subrange
 from tilequeue.tile import coord_int_zoom_up
 from tilequeue.tile import coord_is_valid
 from tilequeue.tile import coord_marshall_int
@@ -26,6 +28,7 @@ from tilequeue.tile import coord_unmarshall_int
 from tilequeue.tile import create_coord
 from tilequeue.tile import deserialize_coord
 from tilequeue.tile import metatile_zoom_from_str
+from tilequeue.tile import n_tiles_in_zoom
 from tilequeue.tile import seed_tiles
 from tilequeue.tile import serialize_coord
 from tilequeue.tile import tile_generator_for_multiple_bounds
@@ -1877,31 +1880,37 @@ def tilequeue_rawr_tile(cfg, args):
     assert group_by_zoom is not None, 'Missing group-zoom rawr config'
     rawr_gen, conn_ctx = _tilequeue_rawr_setup(cfg)
 
+    batch_yaml = cfg.yml.get('batch')
+    assert batch_yaml, 'Missing batch config'
+    queue_zoom = batch_yaml.get('queue-zoom')
+    assert queue_zoom, 'Missing batch queue-zoom config'
+    assert 0 <= parent.zoom <= queue_zoom
+
     logger = make_logger(cfg, 'rawr_tile')
     rawr_tile_logger = JsonRawrTileLogger(logger, run_id)
     rawr_tile_logger.lifecycle(parent, 'Rawr tile generation started')
 
-    parent_timing = {}
-    with time_block(parent_timing, 'total'):
-        job_coords = find_job_coords_for(parent, group_by_zoom)
-        for coord in job_coords:
-            try:
-                coord_timing = {}
-                with time_block(coord_timing, 'total'):
-                    rawr_tile_coord = convert_coord_object(coord)
-                    with conn_ctx() as conn:
-                        # commit transaction
-                        with conn as conn:
-                            # cleanup cursor resources
-                            with conn.cursor() as cur:
-                                table_reader = TableReader(cur)
-                                rawr_gen_timing = rawr_gen(
-                                    table_reader, rawr_tile_coord)
-                                coord_timing['gen'] = rawr_gen_timing
-                rawr_tile_logger.coord_done(parent, coord, coord_timing)
-            except Exception as e:
-                rawr_tile_logger.error(e, parent, coord)
-    rawr_tile_logger.parent_coord_done(parent, parent_timing)
+    coord = get_batch_job_coord(
+        get_batch_job_coords_high_zoom(parent, queue_zoom, group_by_zoom))
+    if coord is None:
+        rawr_tile_logger.invalid_job_coord(parent)
+        return
+    try:
+        coord_timing = {}
+        with time_block(coord_timing, 'total'):
+            rawr_tile_coord = convert_coord_object(coord)
+            with conn_ctx() as conn:
+                # commit transaction
+                with conn as conn:
+                    # cleanup cursor resources
+                    with conn.cursor() as cur:
+                        table_reader = TableReader(cur)
+                        rawr_gen_timing = rawr_gen(
+                            table_reader, rawr_tile_coord)
+                        coord_timing['gen'] = rawr_gen_timing
+        rawr_tile_logger.coord_done(parent, coord, coord_timing)
+    except Exception as e:
+        rawr_tile_logger.error(e, parent, coord)
 
     rawr_tile_logger.lifecycle(parent, 'Rawr tile generation finished')
 
@@ -1993,6 +2002,28 @@ def tilequeue_batch_enqueue(cfg, args):
 
     check_metatile_exists = batch_yaml.get('check-metatile-exists')
 
+    # determine the "job_size", which is the size of the batch array jobs when
+    # we enqueue tiles at the queue zoom. This is different for low zoom tiles
+    # and high zoom tiles.
+    # low zoom:  z7 coord represents all tiles at z7, z8, z9
+    # high zoom: z7 coord represents all tiles at z10 equivalent
+    # (the jobs at z10 themselves represent the whole pyramid for the job)
+    # NOTE: enqueueing rawr tiles uses the high zoom model
+    rawr_yaml = cfg.yml.get('rawr')
+    assert rawr_yaml is not None, 'Missing rawr configuration in yaml'
+    group_by_zoom = rawr_yaml.get('group-zoom')
+    assert group_by_zoom is not None, 'Missing group-zoom rawr config'
+    job_type = batch_yaml.get('job-type')
+    assert job_type, 'Missing batch job-type config'
+    assert job_type in ('low', 'high'), 'Invalid batch job-type config'
+    job_size = None
+    if job_type == 'low':
+        job_size = n_tiles_in_zoom(group_by_zoom - queue_zoom - 1)
+    elif job_type == 'high':
+        job_size = 4 ** (group_by_zoom - queue_zoom)
+    else:
+        assert 0, 'Unknown job_type: %s' % job_type
+
     retry_attempts = batch_yaml.get('retry-attempts')
     memory = batch_yaml.get('memory')
     vcpus = batch_yaml.get('vcpus')
@@ -2008,7 +2039,7 @@ def tilequeue_batch_enqueue(cfg, args):
         assert coord, 'Invalid coord: %s' % args.tile
         coords = [coord]
     elif args.pyramid:
-        coords = tile_generator_for_range(0, 0, 0, 0, 0, 7)
+        coords = tile_generator_for_range(0, 0, 0, 0, 0, queue_zoom)
     else:
         dim = 2 ** queue_zoom
         coords = tile_generator_for_range(
@@ -2030,6 +2061,8 @@ def tilequeue_batch_enqueue(cfg, args):
         )
         if retry_attempts is not None:
             job_opts['retryStrategy'] = dict(attempts=retry_attempts)
+        if coord.zoom == queue_zoom:
+            job_opts['arrayProperties'] = dict(size=job_size)
         container_overrides = {}
         if check_metatile_exists is not None:
             container_overrides['environment'] = {
@@ -2124,20 +2157,44 @@ def tilequeue_meta_tile(cfg, args):
     zip_format = lookup_format_by_extension('zip')
     assert zip_format
 
-    job_coords = find_job_coords_for(parent, group_by_zoom)
-    for job_coord in job_coords:
+    job_coord = get_batch_job_coord(
+        get_batch_job_coords_high_zoom(parent, queue_zoom, group_by_zoom))
+    if job_coord is None:
+        meta_tile_logger.invalid_job_coord(parent)
+        return
 
-        meta_tile_logger.begin_pyramid(parent, job_coord)
+    meta_tile_logger.begin_pyramid(parent, job_coord)
 
-        # each coord here is the unit of work now
-        pyramid_coords = [job_coord]
-        pyramid_coords.extend(coord_children_range(job_coord, zoom_stop))
-        coord_data = [dict(coord=x) for x in pyramid_coords]
+    pyramid_coords = [job_coord]
+    pyramid_coords.extend(coord_children_range(job_coord, zoom_stop))
+    coord_data = [dict(coord=x) for x in pyramid_coords]
+
+    try:
+        fetched_coord_data = list(data_fetcher.fetch_tiles(coord_data))
+    except Exception as e:
+        meta_tile_logger.pyramid_fetch_failed(e, parent, job_coord)
+        return
+
+    for fetch, coord_datum in fetched_coord_data:
+        coord = coord_datum['coord']
+        if check_metatile_exists:
+            existing_data = store.read_tile(coord, zip_format)
+            if existing_data is not None:
+                meta_tile_logger.metatile_already_exists(
+                    parent, job_coord, coord)
+                continue
+
+        processor = Processor(
+            coord, cfg.metatile_zoom, fetch, layer_data,
+            post_process_data, formats, cfg.buffer_cfg,
+            output_calc_mapping, cfg.max_zoom, cfg.tile_sizes)
 
         try:
-            fetched_coord_data = list(data_fetcher.fetch_tiles(coord_data))
+            processor.fetch()
+
         except Exception as e:
-            meta_tile_logger.pyramid_fetch_failed(e, parent, job_coord)
+            meta_tile_logger.tile_fetch_failed(
+                e, parent, job_coord, coord)
             continue
 
         for fetch, coord_datum in fetched_coord_data:
@@ -2148,42 +2205,51 @@ def tilequeue_meta_tile(cfg, args):
                     meta_tile_logger.metatile_already_exists(
                         parent, job_coord, coord)
                     continue
+        try:
+            formatted_tiles, _ = processor.process_tiles()
 
-            processor = Processor(
-                coord, cfg.metatile_zoom, fetch, layer_data,
-                post_process_data, formats, cfg.buffer_cfg,
-                output_calc_mapping, cfg.max_zoom, cfg.tile_sizes)
+        except Exception as e:
+            meta_tile_logger.tile_process_failed(
+                e, parent, job_coord, coord)
 
-            try:
-                processor.fetch()
+        try:
+            tiles = make_metatiles(cfg.metatile_size, formatted_tiles)
+            for tile in tiles:
+                store.write_tile(
+                    tile['tile'], tile['coord'], tile['format'],
+                    tile['layer'])
+        except Exception as e:
+            meta_tile_logger.metatile_storage_failed(
+                e, parent, job_coord, coord)
+            continue
 
-            except Exception as e:
-                meta_tile_logger.tile_fetch_failed(
-                    e, parent, job_coord, coord)
-                continue
+        meta_tile_logger.tile_processed(parent, job_coord, coord)
 
-            try:
-                formatted_tiles, _ = processor.process_tiles()
+    meta_tile_logger.end_pyramid(parent, job_coord)
 
-            except Exception as e:
-                meta_tile_logger.tile_process_failed(
-                    e, parent, job_coord, coord)
 
-            try:
-                tiles = make_metatiles(cfg.metatile_size, formatted_tiles)
-                for tile in tiles:
-                    store.write_tile(
-                        tile['tile'], tile['coord'], tile['format'])
-            except Exception as e:
-                meta_tile_logger.metatile_storage_failed(
-                    e, parent, job_coord, coord)
-                continue
+def get_batch_job_coord(coords, job_idx=None):
+    if job_idx is None:
+        job_idx_str = os.getenv('AWS_BATCH_JOB_ARRAY_INDEX')
+        if job_idx_str is None:
+            return None
+        try:
+            job_idx = int(job_idx_str)
+        except ValueError:
+            return None
+    if job_idx < 0:
+        return None
+    return next(islice(coords, job_idx, None), None)
 
-            meta_tile_logger.tile_processed(parent, job_coord, coord)
 
-        meta_tile_logger.end_pyramid(parent, job_coord)
+def get_batch_job_coords_low_zoom(coord, queue_zoom, group_by_zoom):
+    # all tiles at z7, z8, z9
+    return coord_children_subrange(coord, queue_zoom, group_by_zoom-1)
 
-    meta_tile_logger.end_run(parent)
+
+def get_batch_job_coords_high_zoom(coord, queue_zoom, group_by_zoom):
+    # all tiles at z10 for z7 area
+    return coord_children_subrange(coord, group_by_zoom, group_by_zoom)
 
 
 def tilequeue_meta_tile_low_zoom(cfg, args):
@@ -2241,67 +2307,63 @@ def tilequeue_meta_tile_low_zoom(cfg, args):
     zip_format = lookup_format_by_extension('zip')
     assert zip_format
 
-    meta_low_zoom_logger.begin_run(parent)
-
-    coords = [parent]
+    coord = parent
     if parent.zoom == queue_zoom:
-        # we will be multiple meta tile coordinates in this run
-        coords.extend(coord_children_range(parent, group_by_zoom - 1))
+        # at the queue zoom, an environment variable will tell us
+        # which coordinate this job represents
+        coord = get_batch_job_coord(
+            get_batch_job_coords_low_zoom(coord, queue_zoom, group_by_zoom))
+        meta_low_zoom_logger.invalid_job_coord(coord)
+        return
 
-    for coord in coords:
-        if check_metatile_exists:
-            existing_data = store.read_tile(coord, zip_format)
-            if existing_data is not None:
-                meta_low_zoom_logger.metatile_already_exists(parent, coord)
-                continue
+    if check_metatile_exists:
+        existing_data = store.read_tile(coord, zip_format)
+        if existing_data is not None:
+            meta_low_zoom_logger.metatile_already_exists(parent, coord)
+            return
 
-        coord_data = [dict(coord=coord)]
-        try:
-            fetched_coord_data = list(data_fetcher.fetch_tiles(coord_data))
-        except Exception as e:
-            # the postgres db fetch doesn't perform the fetch at
-            # this step, which would make failures here very
-            # surprising
-            meta_low_zoom_logger.fetch_failed(e, parent, coord)
-            continue
+    coord_data = [dict(coord=coord)]
+    try:
+        fetched_coord_data = list(data_fetcher.fetch_tiles(coord_data))
+    except Exception as e:
+        # the postgres db fetch doesn't perform the fetch at
+        # this step, which would make failures here very
+        # surprising
+        meta_low_zoom_logger.fetch_failed(e, parent, coord)
+        return
 
-        assert len(fetched_coord_data) == 1
-        fetch, coord_datum = fetched_coord_data[0]
-        coord = coord_datum['coord']
+    assert len(fetched_coord_data) == 1
+    fetch, coord_datum = fetched_coord_data[0]
+    coord = coord_datum['coord']
 
-        processor = Processor(
-            coord, cfg.metatile_zoom, fetch, layer_data,
-            post_process_data, formats, cfg.buffer_cfg,
-            output_calc_mapping, cfg.max_zoom, cfg.tile_sizes)
+    processor = Processor(
+        coord, cfg.metatile_zoom, fetch, layer_data,
+        post_process_data, formats, cfg.buffer_cfg,
+        output_calc_mapping, cfg.max_zoom, cfg.tile_sizes)
 
-        try:
-            processor.fetch()
+    try:
+        processor.fetch()
 
-        except Exception as e:
-            meta_low_zoom_logger.fetch_failed(
-                e, parent, coord)
-            continue
+    except Exception as e:
+        meta_low_zoom_logger.fetch_failed(e, parent, coord)
+        return
 
-        try:
-            formatted_tiles, _ = processor.process_tiles()
+    try:
+        formatted_tiles, _ = processor.process_tiles()
+    except Exception as e:
+        meta_low_zoom_logger.tile_process_failed(e, parent, coord)
+        return
 
-        except Exception as e:
-            meta_low_zoom_logger.tile_process_failed(
-                e, parent, coord)
-            continue
+    try:
+        tiles = make_metatiles(cfg.metatile_size, formatted_tiles)
+        for tile in tiles:
+            store.write_tile(tile['tile'], tile['coord'], tile['format'])
+    except Exception as e:
+        meta_low_zoom_logger.metatile_storage_failed(
+            e, parent, coord)
+        return
 
-        try:
-            tiles = make_metatiles(cfg.metatile_size, formatted_tiles)
-            for tile in tiles:
-                store.write_tile(tile['tile'], tile['coord'], tile['format'])
-        except Exception as e:
-            meta_low_zoom_logger.metatile_storage_failed(
-                e, parent, coord)
-            continue
-
-        meta_low_zoom_logger.tile_processed(parent, coord)
-
-    meta_low_zoom_logger.end_run(parent)
+    meta_low_zoom_logger.tile_processed(parent, coord)
 
 
 def tilequeue_main(argv_args=None):

--- a/tilequeue/log.py
+++ b/tilequeue/log.py
@@ -295,17 +295,16 @@ class JsonRawrTileLogger(object):
         json_str = json.dumps(json_obj)
         self.logger.info(json_str)
 
-    def parent_coord_done(self, parent, timing):
+    def invalid_job_coord(self, parent):
         json_obj = dict(
-            type=log_level_name(LogLevel.INFO),
-            msg_type=log_msg_type_name(MsgType.PYRAMID),
+            type=log_level_name(LogLevel.ERROR),
             category=log_category_name(LogCategory.RAWR_TILE),
+            msg='could not find job coordinate',
             parent=make_coord_dict(parent),
-            timing=timing,
             run_id=self.run_id,
         )
         json_str = json.dumps(json_obj)
-        self.logger.info(json_str)
+        self.logger.error(json_str)
 
 
 class MultipleMessagesTrackerLogger(object):
@@ -359,12 +358,6 @@ class JsonMetaTileLogger(object):
         json_str = json.dumps(json_obj)
         self.logger.info(json_str)
 
-    def begin_run(self, parent):
-        self._log('batch process run begin', parent)
-
-    def end_run(self, parent):
-        self._log('batch process run end', parent)
-
     def begin_pyramid(self, parent, pyramid):
         self._log('pyramid begin', parent, pyramid)
 
@@ -408,6 +401,17 @@ class JsonMetaTileLogger(object):
 
     def metatile_already_exists(self, parent, pyramid, coord):
         self._log('metatile already exists', parent, pyramid, coord)
+
+    def invalid_job_coord(self, parent):
+        json_obj = dict(
+            parent=make_coord_dict(parent),
+            type=log_level_name(LogLevel.ERROR),
+            category=log_category_name(LogCategory.META_TILE),
+            msg='could not find job coordinate',
+            run_id=self.run_id,
+        )
+        json_str = json.dumps(json_obj)
+        self.logger.error(json_str)
 
 
 class JsonMetaTileLowZoomLogger(object):
@@ -466,8 +470,13 @@ class JsonMetaTileLowZoomLogger(object):
     def tile_processed(self, parent, coord):
         self._log('tile processed', parent, coord)
 
-    def begin_run(self, parent):
-        self._log('low zoom tile run begin', parent)
-
-    def end_run(self, parent):
-        self._log('low zoom tile run end', parent)
+    def invalid_job_coord(self, parent):
+        json_obj = dict(
+            type=log_level_name(LogLevel.ERROR),
+            category=log_category_name(LogCategory.META_TILE_LOW_ZOOM),
+            msg='could not find job coordinate',
+            parent=make_coord_dict(parent),
+            run_id=self.run_id,
+        )
+        json_str = json.dumps(json_obj)
+        self.logger.error(json_str)


### PR DESCRIPTION
This effectively unpacks the batch job types at the queue zooms (z7) one level to take advantage of batch array jobs. This involves updating the enqueue process to be set the correct job size, and modifying the rawr/low/high tile generations to be aware of this.

Unfortunately, the diff looks more aggressive than it is because the indentation changed throughout, but it boils down to removing the outer loop around what the z7 tile represents.