### PR TITLE
Revert back to using individual jobs.

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -439,13 +439,6 @@ batch:
   retry-attempts: 5
   # check store if metatile already exists, and if so skip processing
   check-metatile-exists: true
-  # used when enqueueing batch array jobs, the job-type can be "low" or "high"
-  # this affects the batch array jobs size
-  # low:  z7 coord represents all tiles at z7, z8, z9
-  # high: z7 coord represents all tiles at z10 equivalent
-  # when enqueueing low zoom metatiles, z0-9, set to "low"
-  # when enqueueing high zoom metatiles and rawr tiles, set to "high"
-  job-type: <job-type>
   # optional override memory reserved for container when submiting job
   # NOTE: in megabytes
   # https://docs.aws.amazon.com/batch/latest/APIReference/API_ContainerOverrides.html

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -142,38 +142,3 @@ class ZoomToQueueNameMapTest(unittest.TestCase):
         zoom = long(7)
         queue_name = get_queue(zoom)
         self.assertEqual(queue_name, 'q1')
-
-
-class BatchJobCoordTest(unittest.TestCase):
-
-    def test_low_zoom(self):
-        from tilequeue.command import get_batch_job_coords_low_zoom
-        from tilequeue.tile import deserialize_coord
-        coord = deserialize_coord('7/0/0')
-        coords = list(get_batch_job_coords_low_zoom(coord, 7, 10))
-        for c in coords:
-            self.assertTrue(7 <= c.zoom <= 9)
-        self.assertEqual(21, len(coords))
-
-    def test_high_zoom(self):
-        from tilequeue.command import get_batch_job_coords_high_zoom
-        from tilequeue.tile import deserialize_coord
-        coord = deserialize_coord('7/0/0')
-        coords = list(get_batch_job_coords_high_zoom(coord, 7, 10))
-        for c in coords:
-            self.assertTrue(c.zoom == 10)
-        self.assertEqual(64, len(coords))
-
-    def test_get_batch_job_coord_idx(self):
-        from tilequeue.command import get_batch_job_coord
-        from tilequeue.tile import deserialize_coord
-        coords = [deserialize_coord('10/1/1')]
-        self.assertIsNotNone(get_batch_job_coord(coords, 0))
-        self.assertIsNone(get_batch_job_coord(coords, -1))
-        self.assertIsNone(get_batch_job_coord(coords, 1))
-        import os
-        self.assertIsNone(get_batch_job_coord(coords))
-        os.environ['AWS_BATCH_JOB_ARRAY_INDEX'] = '0'
-        self.assertIsNotNone(get_batch_job_coord(coords))
-        os.environ['AWS_BATCH_JOB_ARRAY_INDEX'] = '1'
-        self.assertIsNone(get_batch_job_coord(coords))

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -2031,9 +2031,11 @@ def tilequeue_batch_enqueue(cfg, args):
             job_opts['retryStrategy'] = dict(attempts=retry_attempts)
         container_overrides = {}
         if check_metatile_exists is not None:
-            container_overrides['environment'] = {
-                'check-metatile-exists': bool(check_metatile_exists),
-            },
+            val_str = str(bool(check_metatile_exists))
+            container_overrides['environment'] = dict(
+                name='TILEQUEUE__BATCH__CHECK-METATILE-EXISTS',
+                value=val_str
+            ),
         if memory:
             container_overrides['memory'] = memory
         if vcpus:

--- a/tilequeue/log.py
+++ b/tilequeue/log.py
@@ -295,16 +295,17 @@ class JsonRawrTileLogger(object):
         json_str = json.dumps(json_obj)
         self.logger.info(json_str)
 
-    def invalid_job_coord(self, parent):
+    def parent_coord_done(self, parent, timing):
         json_obj = dict(
-            type=log_level_name(LogLevel.ERROR),
+            type=log_level_name(LogLevel.INFO),
+            msg_type=log_msg_type_name(MsgType.PYRAMID),
             category=log_category_name(LogCategory.RAWR_TILE),
-            msg='could not find job coordinate',
             parent=make_coord_dict(parent),
+            timing=timing,
             run_id=self.run_id,
         )
         json_str = json.dumps(json_obj)
-        self.logger.error(json_str)
+        self.logger.info(json_str)
 
 
 class MultipleMessagesTrackerLogger(object):
@@ -358,6 +359,12 @@ class JsonMetaTileLogger(object):
         json_str = json.dumps(json_obj)
         self.logger.info(json_str)
 
+    def begin_run(self, parent):
+        self._log('batch process run begin', parent)
+
+    def end_run(self, parent):
+        self._log('batch process run end', parent)
+
     def begin_pyramid(self, parent, pyramid):
         self._log('pyramid begin', parent, pyramid)
 
@@ -401,17 +408,6 @@ class JsonMetaTileLogger(object):
 
     def metatile_already_exists(self, parent, pyramid, coord):
         self._log('metatile already exists', parent, pyramid, coord)
-
-    def invalid_job_coord(self, parent):
-        json_obj = dict(
-            parent=make_coord_dict(parent),
-            type=log_level_name(LogLevel.ERROR),
-            category=log_category_name(LogCategory.META_TILE),
-            msg='could not find job coordinate',
-            run_id=self.run_id,
-        )
-        json_str = json.dumps(json_obj)
-        self.logger.error(json_str)
 
 
 class JsonMetaTileLowZoomLogger(object):
@@ -470,13 +466,8 @@ class JsonMetaTileLowZoomLogger(object):
     def tile_processed(self, parent, coord):
         self._log('tile processed', parent, coord)
 
-    def invalid_job_coord(self, parent):
-        json_obj = dict(
-            type=log_level_name(LogLevel.ERROR),
-            category=log_category_name(LogCategory.META_TILE_LOW_ZOOM),
-            msg='could not find job coordinate',
-            parent=make_coord_dict(parent),
-            run_id=self.run_id,
-        )
-        json_str = json.dumps(json_obj)
-        self.logger.error(json_str)
+    def begin_run(self, parent):
+        self._log('low zoom tile run begin', parent)
+
+    def end_run(self, parent):
+        self._log('low zoom tile run end', parent)


### PR DESCRIPTION
In #347, we started to use [AWS Batch array jobs](https://docs.aws.amazon.com/batch/latest/userguide/array_jobs.html) so that we didn't have to manually "unpack" a job as a zoom 7 coordinate into its zoom 10 descendants. This should have had the advantage of each individual zoom 10 job being scheduled independently, leading to better load balance.

Unfortunately, we ran into some problems with the array jobs which drastically reduced throughput. Until those are cleared up, for practical reasons it's necessary to revert back to the old way of doing things.
