### PR TITLE
Add missing 'continue' statement after logging exception.

### DIFF
--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -2169,6 +2169,7 @@ def tilequeue_meta_tile(cfg, args):
             except Exception as e:
                 meta_tile_logger.tile_process_failed(
                     e, parent, job_coord, coord)
+                continue
 
             try:
                 tiles = make_metatiles(cfg.metatile_size, formatted_tiles)


### PR DESCRIPTION
I think this got lost in a refactor at some point, but the loop should continue to the next tile after logging the exception.