### PR TITLE
Add new coanacatl driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Then:
 
 ### Coanacatl
 
-Note that if you want to configure the `coanacatl` format, you will need to install the [coanacatl](https://github.com/tilezen/coanacatl) library. This is totally optional and tilequeue will work fine with the regular `mvt` format, but can provide some robustness and speed improvements.
+Note that if you want to configure the `coanacatl` format (really an alternative MVT driver), you will need to install the [coanacatl](https://github.com/tilezen/coanacatl) library. This is totally optional and tilequeue will work fine with the regular `mvt` format, but can provide some robustness and speed improvements.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Then:
 
     python setup.py develop
 
+### Coanacatl
+
+Note that if you want to configure the `coanacatl` format, you will need to install the [coanacatl](https://github.com/tilezen/coanacatl) library. This is totally optional and tilequeue will work fine with the regular `mvt` format, but can provide some robustness and speed improvements.
+
 ## Configuration
 
 See [`config.yaml.sample`](https://github.com/tilezen/tilequeue/blob/master/config.yaml.sample)


### PR DESCRIPTION
It's like the existing MVT driver, but using [coanacatl](https://github.com/tilezen/coanacatl) instead of [mapbox_vector_tile](https://github.com/tilezen/mapbox_vector_tile).

It needs extra stuff installed, so it's optional at the moment. I've added a subsection to the README to call that out.