### PR TITLE
Fix high zoom 512/256 tile size

### DIFF
--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -437,7 +437,8 @@ class TestCalculateCutCoords(unittest.TestCase):
         max_zoom = 16
         metatile_zoom = 2
         cut_coords = calculate_cut_coords_by_zoom(
-            _c(max_zoom - metatile_zoom, 0, 0), metatile_zoom, [512], max_zoom)
+            _c(max_zoom - metatile_zoom, 0, 0), metatile_zoom, [512],
+            max_zoom - metatile_zoom)
         self.assertEqual([max_zoom], cut_coords.keys())
         self.assertEqual(set([
             # some 512 tiles
@@ -475,7 +476,7 @@ class TestCalculateCutCoords(unittest.TestCase):
         # & 1.
         metatile_zoom = 3
         cut_coords = calculate_cut_coords_by_zoom(
-            _c(0, 0, 0), metatile_zoom, [512], 16)
+            _c(0, 0, 0), metatile_zoom, [512], 16 - metatile_zoom)
         self.assertEqual([1, 2, 3], cut_coords.keys())
 
         # we get 1x1 nominal zoom 1 tile

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -217,7 +217,7 @@ class TestCalculateCutZooms(unittest.TestCase):
             coord = Coordinate(zoom=max_zoom - metatile_zoom, row=0, column=0)
 
             return calculate_sizes_by_zoom(
-                coord, metatile_zoom, tile_sizes, max_zoom)
+                coord, metatile_zoom, tile_sizes, max_zoom - metatile_zoom)
 
         # sweep max zoom to check the output is the same nominal max zoom.
         self.assertEqual({16: [256]}, _calc(8, [256], 16))
@@ -232,14 +232,34 @@ class TestCalculateCutZooms(unittest.TestCase):
         # have 1024 tiles at mid zooms.
         self.assertEqual({16: [1024, 512, 256]}, _calc(8, [1024], 16))
 
+    def test_only_overzoom_at_max_zoom(self):
+        from tilequeue.process import calculate_sizes_by_zoom
+
+        # constants
+        metatile_zoom = 3
+        cfg_tile_sizes = [512]
+        max_zoom = 13
+
+        # zoom 13 (nominal 16) tile should contain everything
+        sizes = calculate_sizes_by_zoom(
+            Coordinate(zoom=13, column=0, row=0),
+            metatile_zoom, cfg_tile_sizes, max_zoom)
+        self.assertEquals(sizes, {16: [512, 256]})
+
+        # zoom 12 (nominal 15) should be 512 only
+        sizes = calculate_sizes_by_zoom(
+            Coordinate(zoom=12, column=0, row=0),
+            metatile_zoom, cfg_tile_sizes, max_zoom)
+        self.assertEquals(sizes, {15: [512]})
+
     def test_mid_zoom(self):
         from tilequeue.process import calculate_sizes_by_zoom
         from tilequeue.tile import metatile_zoom_from_size
 
-        max_zoom = 16
         tile_sizes = [512]
         metatile_size = 8
         metatile_zoom = metatile_zoom_from_size(metatile_size)
+        max_zoom = 16 - metatile_zoom
 
         for zoom in range(1, max_zoom - metatile_zoom):
             coord = Coordinate(zoom=zoom, row=0, column=0)
@@ -254,8 +274,8 @@ class TestCalculateCutZooms(unittest.TestCase):
 
         def _calc(metatile_size, tile_sizes):
             coord = Coordinate(zoom=0, row=0, column=0)
-            max_zoom = 16
             metatile_zoom = metatile_zoom_from_size(metatile_size)
+            max_zoom = 16 - metatile_zoom
 
             return calculate_sizes_by_zoom(
                 coord, metatile_zoom, tile_sizes, max_zoom)

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -646,6 +646,9 @@ def calculate_sizes_by_zoom(coord, metatile_zoom, cfg_tile_sizes, max_zoom):
 
     For example, with 1x1 metatiles, the tile size is always 256px, and the
     function will return {coord.zoom: [256]}
+
+    Note that max_zoom should be the maximum *coordinate* zoom, not nominal
+    zoom.
     """
 
     from tilequeue.tile import metatile_zoom_from_size
@@ -659,7 +662,7 @@ def calculate_sizes_by_zoom(coord, metatile_zoom, cfg_tile_sizes, max_zoom):
         assert tile_size <= 256 * (1 << metatile_zoom)
         assert _is_power_of_2(tile_size)
 
-    if nominal_zoom >= max_zoom:
+    if coord.zoom >= max_zoom:
         # all the tile_sizes down to 256 at the nominal zoom.
         tile_sizes = []
         tile_sizes.extend(cfg_tile_sizes)
@@ -695,6 +698,9 @@ def calculate_cut_coords_by_zoom(
     """
     Returns a map of nominal zoom to the list of cut coordinates at that
     nominal zoom.
+
+    Note that max_zoom should be the maximum coordinate zoom, not nominal
+    zoom.
     """
 
     tile_sizes_by_zoom = calculate_sizes_by_zoom(


### PR DESCRIPTION
The code was passing the coordinate max zoom to `calculate_sizes_by_zoom`. For example, with 8x8 metatiles and a max nominal zoom of 16, it would pass 13. This meant that 256px tiles were being generated for 3 more zoom levels than we really needed.

Added comments saying it's coordinate zoom and fixed the tests to pass in the coordinate zoom, with a one-line update to the method itself. This should mean we only get 256px tiles at max zoom, and not before.
