### PR TITLE
Pass the tolerance from config through to layer datum.

### DIFF
--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -535,7 +535,7 @@ def parse_layer_data(query_cfg, buffer_cfg, cfg_path):
             area_threshold=area_threshold,
             query_bounds_pad_fn=create_query_bounds_pad_fn(
                 buffer_cfg, layer_name),
-            tolerance=layer_config.get('tolerance', 1.0),
+            tolerance=float(layer_config.get('tolerance', 1.0)),
         )
         layer_data.append(layer_datum)
         if layer_name in all_layer_names:

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -535,6 +535,7 @@ def parse_layer_data(query_cfg, buffer_cfg, cfg_path):
             area_threshold=area_threshold,
             query_bounds_pad_fn=create_query_bounds_pad_fn(
                 buffer_cfg, layer_name),
+            tolerance=layer_config.get('tolerance', 1.0),
         )
         layer_data.append(layer_datum)
         if layer_name in all_layer_names:


### PR DESCRIPTION
The `simplify_and_clip` post-processing transform looks in the layer datum to get the tolerance factor to use for simplifying geometries. Turns out, this wasn't getting passed through from the `queries.yaml` config, so it was just using the default of `1.0` for every layer. Ooops.
