### PR TITLE
Process boundaries from RAWR tiles the same way we do from SQL.

### DIFF
--- a/tests/test_query_rawr.py
+++ b/tests/test_query_rawr.py
@@ -736,8 +736,7 @@ class TestTileFootprint(unittest.TestCase):
 
 class TestBoundaries(RawrTestCase):
 
-    def test_linestrings_dropped(self):
-        from shapely.geometry import LineString
+    def _fetch_data(self, shape_fn, source_table):
         from tilequeue.query.common import LayerInfo
         from tilequeue.query.rawr import make_rawr_data_fetcher
         from tilequeue.tile import coord_to_mercator_bounds
@@ -757,10 +756,7 @@ class TestBoundaries(RawrTestCase):
         top_tile = tile.zoomTo(top_zoom).container()
 
         bounds = coord_to_mercator_bounds(tile)
-        shape = LineString([
-            [bounds[0], bounds[1]],
-            [bounds[2], bounds[3]],
-        ])
+        shape = shape_fn(bounds)
 
         props = {
             'name': 'Foo',
@@ -770,7 +766,7 @@ class TestBoundaries(RawrTestCase):
 
         source = 'test'
         tables = TestGetTable({
-            'planet_osm_line': [
+            source_table: [
                 (1, shape.wkb, props),
             ],
         }, source)
@@ -785,61 +781,38 @@ class TestBoundaries(RawrTestCase):
         for fetcher, _ in fetch.fetch_tiles(_wrap(top_tile)):
             read_rows = fetcher(tile.zoom, coord_to_mercator_bounds(tile))
 
+        return read_rows
+
+    def test_linestrings_dropped(self):
+        # test that linestrings in the RAWR tile don't make it into the tile.
+        from shapely.geometry import LineString
+
+        def _tile_diagonal(bounds):
+            return LineString([
+                [bounds[0], bounds[1]],
+                [bounds[2], bounds[3]],
+            ])
+
+        read_rows = self._fetch_data(_tile_diagonal, 'planet_osm_line')
         self.assertEqual(read_rows, [])
 
     def test_boundaries_from_polygons(self):
+        # check that a polygon in the RAWR tile contributes its oriented
+        # (anti-clockwise) boundary to the tile data.
         from shapely.geometry import Polygon
-        from tilequeue.query.common import LayerInfo
-        from tilequeue.query.rawr import make_rawr_data_fetcher
-        from tilequeue.tile import coord_to_mercator_bounds
-        from ModestMaps.Core import Coordinate
 
-        top_zoom = 10
-        max_zoom = top_zoom + 6
+        def _tile_triangle(bounds):
+            # note: this triangle polygon is the wrong way around (clockwise,
+            # rather than anti-clockwise). this is deliberate, and the code
+            # should deal with it.
+            return Polygon([
+                [bounds[0], bounds[1]],
+                [bounds[2], bounds[1]],
+                [bounds[0], bounds[3]],
+                [bounds[0], bounds[1]],
+            ])
 
-        def min_zoom_fn(shape, props, fid, meta):
-            return top_zoom
-
-        def props_fn(shape, props, fid, meta):
-            return {'kind': 'country'}
-
-        z, x, y = (max_zoom, 0, 0)
-        tile = Coordinate(zoom=z, column=x, row=y)
-        top_tile = tile.zoomTo(top_zoom).container()
-
-        bounds = coord_to_mercator_bounds(tile)
-        # note: this triangle polygon is the wrong way around (clockwise,
-        # rather than anti-clockwise). this is deliberate, and the code should
-        # deal with it.
-        shape = Polygon([
-            [bounds[0], bounds[1]],
-            [bounds[2], bounds[1]],
-            [bounds[0], bounds[3]],
-            [bounds[0], bounds[1]],
-        ])
-
-        props = {
-            'name': 'Foo',
-            'admin_level': '2',
-            'boundary': 'administrative',
-        }
-
-        source = 'test'
-        tables = TestGetTable({
-            'planet_osm_polygon': [
-                (1, shape.wkb, props),
-            ],
-        }, source)
-
-        layers = {
-            'boundaries': LayerInfo(min_zoom_fn, props_fn),
-        }
-        storage = ConstantStorage(tables)
-        fetch = make_rawr_data_fetcher(
-            top_zoom, max_zoom, storage, layers, [dict(type="osm")])
-
-        for fetcher, _ in fetch.fetch_tiles(_wrap(top_tile)):
-            read_rows = fetcher(tile.zoom, coord_to_mercator_bounds(tile))
+        read_rows = self._fetch_data(_tile_triangle, 'planet_osm_polygon')
 
         self.assertEqual(len(read_rows), 1)
         props = read_rows[0]['__boundaries_properties__']

--- a/tests/test_query_rawr.py
+++ b/tests/test_query_rawr.py
@@ -732,3 +732,117 @@ class TestTileFootprint(unittest.TestCase):
                 expected.add(Tile(tile.z, tile.x + dx, tile.y + dy))
 
         self.assertEquals(expected, tiles)
+
+
+class TestBoundaries(RawrTestCase):
+
+    def test_linestrings_dropped(self):
+        from shapely.geometry import LineString
+        from tilequeue.query.common import LayerInfo
+        from tilequeue.query.rawr import make_rawr_data_fetcher
+        from tilequeue.tile import coord_to_mercator_bounds
+        from ModestMaps.Core import Coordinate
+
+        top_zoom = 10
+        max_zoom = top_zoom + 6
+
+        def min_zoom_fn(shape, props, fid, meta):
+            return top_zoom
+
+        def props_fn(shape, props, fid, meta):
+            return {'kind': 'country'}
+
+        z, x, y = (max_zoom, 0, 0)
+        tile = Coordinate(zoom=z, column=x, row=y)
+        top_tile = tile.zoomTo(top_zoom).container()
+
+        bounds = coord_to_mercator_bounds(tile)
+        shape = LineString([
+            [bounds[0], bounds[1]],
+            [bounds[2], bounds[3]],
+        ])
+
+        props = {
+            'name': 'Foo',
+            'admin_level': '2',
+            'boundary': 'administrative',
+        }
+
+        source = 'test'
+        tables = TestGetTable({
+            'planet_osm_line': [
+                (1, shape.wkb, props),
+            ],
+        }, source)
+
+        layers = {
+            'boundaries': LayerInfo(min_zoom_fn, props_fn),
+        }
+        storage = ConstantStorage(tables)
+        fetch = make_rawr_data_fetcher(
+            top_zoom, max_zoom, storage, layers, [dict(type="osm")])
+
+        for fetcher, _ in fetch.fetch_tiles(_wrap(top_tile)):
+            read_rows = fetcher(tile.zoom, coord_to_mercator_bounds(tile))
+
+        self.assertEqual(read_rows, [])
+
+    def test_boundaries_from_polygons(self):
+        from shapely.geometry import Polygon
+        from tilequeue.query.common import LayerInfo
+        from tilequeue.query.rawr import make_rawr_data_fetcher
+        from tilequeue.tile import coord_to_mercator_bounds
+        from ModestMaps.Core import Coordinate
+
+        top_zoom = 10
+        max_zoom = top_zoom + 6
+
+        def min_zoom_fn(shape, props, fid, meta):
+            return top_zoom
+
+        def props_fn(shape, props, fid, meta):
+            return {'kind': 'country'}
+
+        z, x, y = (max_zoom, 0, 0)
+        tile = Coordinate(zoom=z, column=x, row=y)
+        top_tile = tile.zoomTo(top_zoom).container()
+
+        bounds = coord_to_mercator_bounds(tile)
+        # note: this triangle polygon is the wrong way around (clockwise,
+        # rather than anti-clockwise). this is deliberate, and the code should
+        # deal with it.
+        shape = Polygon([
+            [bounds[0], bounds[1]],
+            [bounds[2], bounds[1]],
+            [bounds[0], bounds[3]],
+            [bounds[0], bounds[1]],
+        ])
+
+        props = {
+            'name': 'Foo',
+            'admin_level': '2',
+            'boundary': 'administrative',
+        }
+
+        source = 'test'
+        tables = TestGetTable({
+            'planet_osm_polygon': [
+                (1, shape.wkb, props),
+            ],
+        }, source)
+
+        layers = {
+            'boundaries': LayerInfo(min_zoom_fn, props_fn),
+        }
+        storage = ConstantStorage(tables)
+        fetch = make_rawr_data_fetcher(
+            top_zoom, max_zoom, storage, layers, [dict(type="osm")])
+
+        for fetcher, _ in fetch.fetch_tiles(_wrap(top_tile)):
+            read_rows = fetcher(tile.zoom, coord_to_mercator_bounds(tile))
+
+        self.assertEqual(len(read_rows), 1)
+        props = read_rows[0]['__boundaries_properties__']
+        self.assertEqual(props.get('boundary'), 'administrative')
+        # check no area
+        self.assertIsNone(props.get('area'))

--- a/tilequeue/query/rawr.py
+++ b/tilequeue/query/rawr.py
@@ -743,7 +743,7 @@ class RawrTile(object):
         # nasty hack: in the SQL, we don't query the lines table for
         # boundaries layer features - instead we take the rings (both outer
         # and inner) of the polygon features in the polygons table - which are
-        # also called the "boundary" of the polygon. the back below replicates
+        # also called the "boundary" of the polygon. the hack below replicates
         # the process we have in the SQL query.
         if read_row and '__boundaries_properties__' in read_row:
             if shape.geom_type in ('LineString', 'MultiLineString'):

--- a/tilequeue/query/rawr.py
+++ b/tilequeue/query/rawr.py
@@ -1,5 +1,6 @@
 from collections import namedtuple, defaultdict
 from shapely.geometry import box
+from shapely.geometry import MultiLineString
 from shapely.geometry.polygon import orient
 from shapely.wkb import loads as wkb_loads
 from tilequeue.query.common import layer_properties
@@ -603,7 +604,6 @@ def _lines_only(shape):
     between a line and a polygon. The main idea is to remove points, and any
     other geometry which might throw a wrench in the works.
     """
-    from shapely.geometry import MultiLineString
 
     lines = _explode_lines(shape)
     if len(lines) == 1:

--- a/tilequeue/query/rawr.py
+++ b/tilequeue/query/rawr.py
@@ -741,16 +741,18 @@ class RawrTile(object):
                 generate_label_placement = True
 
         # nasty hack: in the SQL, we don't query the lines table for
-        # boundary features - instead we take the boundaries of the
-        # polygon features in the polygons table. this replicates that
-        # process.
+        # boundaries layer features - instead we take the rings (both outer
+        # and inner) of the polygon features in the polygons table - which are
+        # also called the "boundary" of the polygon. the back below replicates
+        # the process we have in the SQL query.
         if read_row and '__boundaries_properties__' in read_row:
             if shape.geom_type in ('LineString', 'MultiLineString'):
                 read_row.pop('__boundaries_properties__')
 
             elif shape.geom_type in ('Polygon', 'MultiPolygon'):
-                # make sure boundary is oriented in the correct anti-clockwise
-                # direction, which means the interior should be on the left.
+                # make sure boundary rings are oriented in the correct
+                # direction; anti-clockwise for outers and clockwise for
+                # inners, which means the interior should be on the left.
                 boundaries_shape = orient(shape).boundary
 
                 # make sure it's only lines, post-intersection. a polygon-line


### PR DESCRIPTION
We don't query boundaries at all from the `planet_osm_lines` table, instead we select the polygons and generate linestring boundaries from them. This is to ensure that boundaries are correctly oriented with the interior on the left.

However, we weren't doing this for RAWR tiles, and were using the lines from `planet_osm_lines` in their original orientation. The `planet_osm_lines` table contains multiple copies of the line; from the original way, plus any boundary relations it is part of. This meant that the two linestrings making up a section of border were in the same direction, and therefore the boundary would be flipped if the geometry was "used" by the wrong side first (which depends on the order in the file, which is non-deterministic).

The fix for this is a bit of an egregious hack; it just drops any `boundaries` linestrings and turns polygons into their boundaries (clipped to the tile). This matches the SQL in `vector-datasource`, but is `vector-datasource`-specific processing which doesn't seem to belong in `tilequeue`, but I couldn't figure a less hacky way to do it without major refactoring.

Connects to https://github.com/tilezen/vector-datasource/issues/1770.