### PR TITLE
Exclude buffered land polygons from changes made in #362.

### DIFF
--- a/tilequeue/query/rawr.py
+++ b/tilequeue/query/rawr.py
@@ -745,7 +745,11 @@ class RawrTile(object):
         # and inner) of the polygon features in the polygons table - which are
         # also called the "boundary" of the polygon. the hack below replicates
         # the process we have in the SQL query.
-        if read_row and '__boundaries_properties__' in read_row:
+        #
+        # note: we shoe-horn buffered land into boundaries, so we have to
+        # disable this special processing for those features.
+        if read_row and '__boundaries_properties__' in read_row and \
+           read_row['__boundaries_properties__'].get('kind') != 'maritime':
             if shape.geom_type in ('LineString', 'MultiLineString'):
                 read_row.pop('__boundaries_properties__')
 


### PR DESCRIPTION
We include buffered land into the boundaries table, but we want to keep it as a polygon, not turn it into a set of outer/inner ring linestrings.

Note: Tests will fail, will need to rebase onto #366 for fix.

Connects to https://github.com/tilezen/vector-datasource/issues/1811.