### PR TITLE
Reduce high zoom "long tail" of jobs

### DIFF
--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -2096,8 +2096,6 @@ def tilequeue_meta_tile(cfg, args):
     parent = deserialize_coord(coord_str)
     assert parent, 'Invalid coordinate: %s' % coord_str
 
-    assert parent.zoom == queue_zoom, 'Unexpected zoom: %s' % coord_str
-
     with open(cfg.query_cfg) as query_cfg_fp:
         query_cfg = yaml.load(query_cfg_fp)
 
@@ -2115,6 +2113,10 @@ def tilequeue_meta_tile(cfg, args):
 
     group_by_zoom = rawr_yaml.get('group-zoom')
     assert group_by_zoom is not None, 'Missing group-zoom rawr config'
+
+    assert queue_zoom <= parent.zoom <= group_by_zoom, \
+        'Unexpected zoom: %s, zoom should be between %d and %d' % \
+        (coord_str, queue_zoom, group_by_zoom)
 
     # NOTE: max_zoom looks to be inclusive
     zoom_stop = cfg.max_zoom

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -2254,7 +2254,9 @@ def tilequeue_meta_tile_low_zoom(cfg, args):
     meta_low_zoom_logger.begin_run(parent)
 
     coords = [parent]
-    if parent.zoom == queue_zoom:
+    # we don't include tiles at group_by_zoom, so unless parent.zoom is
+    # _more_ than one zoom level less, we don't need to include the pyramid.
+    if parent.zoom == queue_zoom and parent.zoom < group_by_zoom - 1:
         # we will be multiple meta tile coordinates in this run
         coords.extend(coord_children_range(parent, group_by_zoom - 1))
 

--- a/tilequeue/tile.py
+++ b/tilequeue/tile.py
@@ -283,7 +283,8 @@ def coord_children(coord):
 
 
 def coord_children_range(coord, zoom_until):
-    assert zoom_until > coord.zoom
+    assert zoom_until > coord.zoom, 'zoom_until (%r) must be > coord.zoom ' \
+        '(%r)' % (zoom_until, coord)
     for child in coord_children_subrange(coord, coord.zoom + 1, zoom_until):
         yield child
 


### PR DESCRIPTION
Allow coordinates for high zoom meta jobs to be anywhere between the `queue_zoom` and `group_by_zoom` (i.e: RAWR tile zoom) inclusive. That's usually between 7 and 10, respectively. This means we can submit jobs which take a long time individually at zoom 10, rather than grouping them at zoom 7 to reduce the overall number of jobs.

Connects to https://github.com/tilezen/tileops/issues/17, required by https://github.com/tilezen/tileops/pull/47.
