### PR TITLE
OpenStreetMapData.com is now hosted by FOSSGIS at osmdata.openstreetmap.de

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -389,7 +389,7 @@ rawr:
       planet_osm_ways: *osm
       planet_osm_rels: *osm
       wof_neighbourhood: { name: wof, value: whosonfirst.org }
-      water_polygons: &osmdata { name: shp, value: openstreetmapdata.com }
+      water_polygons: &osmdata { name: shp, value: osmdata.openstreetmap.de }
       land_polygons: *osmdata
       ne_10m_urban_areas: { name: ne, value: naturalearthdata.com }
   # when a feature's shape is of the type given in the key and the feature

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -254,8 +254,8 @@ def lookup_source(source):
         result = Source('osm', source)
     elif source == 'naturalearthdata.com':
         result = Source('ne', source)
-    elif source == 'openstreetmapdata.com':
-        result = Source('shp', source)
+    elif source in ('openstreetmapdata.com', 'osmdata.openstreetmap.de'):
+        result = Source('shp', 'osmdata.openstreetmap.de')
     elif source == 'whosonfirst.org':
         result = Source('wof', source)
     elif source == 'tilezen.org':

--- a/tilequeue/query/rawr.py
+++ b/tilequeue/query/rawr.py
@@ -428,7 +428,7 @@ class _SimpleLayersIndex(object):
     Index features by the tile(s) that they appear in.
 
     This is the non-relations version, for stand-alone features such as those
-    from openstreetmapdata.com shapefiles or WOF.
+    from osmdata.openstreetmap.de shapefiles or WOF.
     """
 
     def __init__(self, layers, tile_pyramid, source, start_zoom, end_zoom):


### PR DESCRIPTION
Connects to https://github.com/tilezen/vector-datasource/issues/1855.
