### PR TITLE
Alternate viewpoints changes for RAWR tiles.

### DIFF
--- a/tilequeue/query/rawr.py
+++ b/tilequeue/query/rawr.py
@@ -818,6 +818,10 @@ class RawrTile(object):
                 # we don't want area on boundaries
                 read_row['__boundaries_properties__'].pop('area', None)
 
+                # set a flag to indicate that we transformed this from a
+                # polygon to a boundary.
+                read_row['mz_boundary_from_polygon'] = True
+
         if read_row:
             read_row['__id__'] = fid
 


### PR DESCRIPTION
In tilezen/vector-datasource#1895, I added a little hack to work around the way we change the geometry type of `boundaries` layer features. They used to come entirely from the `planet_osm_polygon` table, but now we also include disputes and claims from `planet_osm_line`. However, we have to filter out a bunch of features from `planet_osm_line` that we don't want, but have the same tags as the polygons we do want.

Long story short: The query in `vector-datasource` sets this flag when transforming a polygon into a boundary line, so we have to do the same thing when reading from the RAWR tiles.

Connects to tilezen/vector-datasource#1810.
