### PR TITLE
Remove transitionary alias used for osmdata sources.

### DIFF
--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -254,7 +254,7 @@ def lookup_source(source):
         result = Source('osm', source)
     elif source == 'naturalearthdata.com':
         result = Source('ne', source)
-    elif source in ('openstreetmapdata.com', 'osmdata.openstreetmap.de'):
+    elif source == 'osmdata.openstreetmap.de':
         result = Source('shp', 'osmdata.openstreetmap.de')
     elif source == 'whosonfirst.org':
         result = Source('wof', source)


### PR DESCRIPTION
Connects to tilezen/vector-datasource#1859.
