### PR TITLE
Fix problems with disputed boundaries from RAWR tiles

### DIFF
--- a/tests/test_query_rawr.py
+++ b/tests/test_query_rawr.py
@@ -783,19 +783,6 @@ class TestBoundaries(RawrTestCase):
 
         return read_rows
 
-    def test_linestrings_dropped(self):
-        # test that linestrings in the RAWR tile don't make it into the tile.
-        from shapely.geometry import LineString
-
-        def _tile_diagonal(bounds):
-            return LineString([
-                [bounds[0], bounds[1]],
-                [bounds[2], bounds[3]],
-            ])
-
-        read_rows = self._fetch_data(_tile_diagonal, 'planet_osm_line')
-        self.assertEqual(read_rows, [])
-
     def test_boundaries_from_polygons(self):
         # check that a polygon in the RAWR tile contributes its oriented
         # (anti-clockwise) boundary to the tile data.
@@ -819,6 +806,8 @@ class TestBoundaries(RawrTestCase):
         self.assertEqual(props.get('boundary'), 'administrative')
         # check no area
         self.assertIsNone(props.get('area'))
+        # check we set the flag
+        self.assertTrue(props.get('mz_boundary_from_polygon'))
 
     def test_boundaries_from_multipolygons(self):
         # check that the boundary extraction code also works for multipolygons
@@ -861,6 +850,8 @@ class TestBoundaries(RawrTestCase):
         self.assertEqual(props.get('boundary'), 'administrative')
         # check no area
         self.assertIsNone(props.get('area'))
+        # check we set the flag
+        self.assertTrue(props.get('mz_boundary_from_polygon'))
 
 
 class TestBufferedLand(RawrTestCase):

--- a/tilequeue/query/rawr.py
+++ b/tilequeue/query/rawr.py
@@ -798,10 +798,7 @@ class RawrTile(object):
         # disable this special processing for those features.
         if read_row and '__boundaries_properties__' in read_row and \
            read_row['__boundaries_properties__'].get('kind') != 'maritime':
-            if shape.geom_type in ('LineString', 'MultiLineString'):
-                read_row.pop('__boundaries_properties__')
-
-            elif shape.geom_type in ('Polygon', 'MultiPolygon'):
+            if shape.geom_type in ('Polygon', 'MultiPolygon'):
                 # make sure boundary rings are oriented in the correct
                 # direction; anti-clockwise for outers and clockwise for
                 # inners, which means the interior should be on the left.
@@ -815,12 +812,14 @@ class RawrTile(object):
                 clip_shape = _lines_only(boundaries_shape.intersection(bbox))
                 read_row['__boundaries_geometry__'] = bytes(clip_shape.wkb)
 
+                boundary_props = read_row['__boundaries_properties__']
                 # we don't want area on boundaries
-                read_row['__boundaries_properties__'].pop('area', None)
+                boundary_props.pop('area', None)
+                boundary_props.pop('way_area', None)
 
                 # set a flag to indicate that we transformed this from a
                 # polygon to a boundary.
-                read_row['mz_boundary_from_polygon'] = True
+                boundary_props['mz_boundary_from_polygon'] = True
 
         if read_row:
             read_row['__id__'] = fid


### PR DESCRIPTION
Fixes build problems discovered during the v1.8d build:

1. The code was dropping all linestrings. This used to be the correct behaviour, but now claims and disputes are included as line features and these should not be dropped any more.
2. After converting from the polygon to the boundary, the `mz_boundary_from_polygon` flag was being set on the wrong set of properties. This caused a downstream process to explode, since the feature no longer matched any of the YAML rules.
