### PR TITLE
Add message to rawr tile processed

### DIFF
--- a/tilequeue/log.py
+++ b/tilequeue/log.py
@@ -289,6 +289,7 @@ class JsonRawrTileLogger(object):
             category=log_category_name(LogCategory.RAWR_TILE),
             coord=make_coord_dict(coord),
             parent=make_coord_dict(parent),
+            msg='tile processed',
             timing=timing,
             run_id=self.run_id,
         )


### PR DESCRIPTION
to make rawr tile message in parity with high/low zoom meta tile, we add a message to rawr tile logger.