### PR TITLE
Add AWS credentials refresh client helper

### DIFF
--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,6 +1,6 @@
-'''
+"""
 Tests for `tilequeue.store`.
-'''
+"""
 
 import unittest
 

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -1775,7 +1775,6 @@ def _tilequeue_rawr_setup(cfg,
     from tilequeue.rawr import RawrS3Sink
     from tilequeue.rawr import RawrStoreSink
     import boto3
-    import botocore
     # pass through the postgresql yaml config directly
     conn_ctx = ConnectionContextManager(rawr_postgresql_yaml)
 

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -38,6 +38,7 @@ from tilequeue.top_tiles import parse_top_tiles
 from tilequeue.utils import grouper
 from tilequeue.utils import parse_log_file
 from tilequeue.utils import time_block
+from tilequeue.utils import AwsSessionHelper
 from tilequeue.worker import DataFetch
 from tilequeue.worker import ProcessAndFormatData
 from tilequeue.worker import QueuePrint
@@ -1813,21 +1814,11 @@ def _tilequeue_rawr_setup(cfg,
             tile_key_gen = make_s3_tile_key_generator(s3_cfg)
 
             if s3_role_arn:
-                # use provided role to access S3
-                assert s3_role_session_duration_s, \
-                    's3_role_session_duration_s is either None or 0'
-                session = botocore.session.get_session()
-                client = session.create_client('sts')
-                assume_role_object = \
-                    client.assume_role(RoleArn=s3_role_arn,
-                                       RoleSessionName='tilequeue_dataaccess',
-                                       DurationSeconds=s3_role_session_duration_s)
-                creds = assume_role_object['Credentials']
-                s3_client = boto3.client('s3',
-                                         region_name=sink_region,
-                                         aws_access_key_id=creds['AccessKeyId'],
-                                         aws_secret_access_key=creds['SecretAccessKey'],
-                                         aws_session_token=creds['SessionToken'])
+                aws_helper = AwsSessionHelper('tilequeue_dataaccess',
+                                              s3_role_arn,
+                                              sink_region,
+                                              s3_role_session_duration_s)
+                s3_client = aws_helper.get_client('s3')
             else:
                 s3_client = boto3.client('s3', region_name=sink_region)
             rawr_sink = RawrS3Sink(

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -1814,6 +1814,9 @@ def _tilequeue_rawr_setup(cfg,
             tile_key_gen = make_s3_tile_key_generator(s3_cfg)
 
             if s3_role_arn:
+                # use provided role to access S3
+                assert s3_role_session_duration_s, \
+                    's3_role_session_duration_s is either None or 0'
                 aws_helper = AwsSessionHelper('tilequeue_dataaccess',
                                               s3_role_arn,
                                               sink_region,

--- a/tilequeue/query/__init__.py
+++ b/tilequeue/query/__init__.py
@@ -122,6 +122,9 @@ def _make_rawr_fetcher(cfg, layer_data,
         import boto3
         from tilequeue.rawr import RawrS3Source
         if s3_role_arn:
+            # use provided role to access S3
+            assert s3_role_session_duration_s, \
+                's3_role_session_duration_s is either None or 0'
             aws_helper = AwsSessionHelper('tilequeue_dataaccess',
                                           s3_role_arn,
                                           region,

--- a/tilequeue/store.py
+++ b/tilequeue/store.py
@@ -2,7 +2,6 @@
 
 import boto3
 from botocore.exceptions import ClientError
-import botocore.session
 from builtins import range
 from enum import Enum
 from future.utils import raise_from

--- a/tilequeue/store.py
+++ b/tilequeue/store.py
@@ -523,8 +523,12 @@ def make_s3_store(cfg_name, tile_key_gen,
                   delete_retry_interval=60, logger=None,
                   object_acl='public-read', tags=None):
     if s3_role_arn:
+        # use provided role to access S3
+        assert s3_role_session_duration_s, \
+            's3_role_session_duration_s is either None or 0'
         aws_helper = AwsSessionHelper('tilequeue_dataaccess',
                                       s3_role_arn,
+                                      'us-east-1',
                                       s3_role_session_duration_s)
         s3 = aws_helper.get_client('s3')
     else:

--- a/tilequeue/utils.py
+++ b/tilequeue/utils.py
@@ -126,10 +126,8 @@ def convert_seconds_to_millis(time_in_seconds):
 
 
 class AwsSessionHelper:
-    """ The AwsSessionHelper creates a autorefreshable refreshable boto3
-        session object
-        and allows for creating clients and resources with those refreshable
-        credentials.
+    """ The AwsSessionHelper creates a auto-refreshable boto3 session object
+        and allows for creating clients with those refreshable credentials.
     """
 
     def __init__(self, session_name, role_arn, region='us-east-1',
@@ -137,6 +135,7 @@ class AwsSessionHelper:
         """ session_name: str; The name of the session we are creating
             role_arn: str; The ARN of the role we are assuming with STS
             region: str; The region for the STS client to be created in
+            s3_role_session_duration_s: int; the time that session is good for
         """
         self.role_arn = role_arn
         self.session_name = session_name

--- a/tilequeue/utils.py
+++ b/tilequeue/utils.py
@@ -1,3 +1,4 @@
+import boto3
 import sys
 import traceback
 import re
@@ -7,6 +8,8 @@ from itertools import islice
 from tilequeue.tile import coord_marshall_int
 from tilequeue.tile import create_coord
 from time import time
+from botocore.credentials import RefreshableCredentials
+from botocore.session import get_session
 
 
 def format_stacktrace_one_line(exc_info=None):
@@ -120,3 +123,65 @@ class CoordsByParent(object):
 def convert_seconds_to_millis(time_in_seconds):
     time_in_millis = int(time_in_seconds * 1000)
     return time_in_millis
+
+
+class AwsSessionHelper:
+    """ The AwsSessionHelper creates a autorefreshable refreshable boto3
+        session object
+        and allows for creating clients and resources with those refreshable
+        credentials.
+    """
+
+    def __init__(self, session_name, role_arn, region='us-east-1',
+                 s3_role_session_duration_s=3600):
+        """ session_name: str; The name of the session we are creating
+            role_arn: str; The ARN of the role we are assuming with STS
+            region: str; The region for the STS client to be created in
+        """
+        self.role_arn = role_arn
+        self.session_name = session_name
+        self.region = region
+        self.session_duration_seconds = s3_role_session_duration_s
+        self.sts_client = boto3.client('sts')
+
+        credentials = self._refresh()
+        session_credentials = RefreshableCredentials.create_from_metadata(
+            metadata=credentials,
+            refresh_using=self._refresh,
+            method="sts-assume-role"
+        )
+        aws_session = get_session()
+        aws_session._credentials = session_credentials
+        aws_session.set_config_variable("region", region)
+        self.aws_session = boto3.Session(botocore_session=aws_session)
+
+    def get_client(self, service):
+        """ Returns boto3.client with the refreshable session
+
+            service: str; String of what service to create a client for
+            (e.g. 'sqs', 's3')
+        """
+        return self.aws_session.client(service)
+
+    def get_session(self):
+        """ Returns the raw refreshable aws session
+        """
+        return self.aws_session
+
+    def _refresh(self):
+        params = {
+            "RoleArn": self.role_arn,
+            "RoleSessionName": self.session_name,
+            "DurationSeconds": self.session_duration_seconds,
+        }
+
+        response = self.sts_client.assume_role(**params).get("Credentials")
+        credentials = {
+            "access_key": response.get("AccessKeyId"),
+            "secret_key": response.get("SecretAccessKey"),
+            "token": response.get("SessionToken"),
+            "expiry_time": response.get("Expiration").isoformat(),
+        }
+        print("Created/refreshed AWS session with name {} and role arn {}".
+              format(self.session_name, self.role_arn))
+        return credentials


### PR DESCRIPTION
Some tiles that takes a long time won't finish in one session, so we need a client which can refresh credentials automatically.