### PR TITLE
separate metatile rawrtile buckets config override

### DIFF
--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -2601,8 +2601,13 @@ def tilequeue_main(argv_args=None):
     subparser.add_argument('--store_name', required=False,
                            help='optional string of a list of tile store '
                                 'names e.g. `["my-meta-tiles-us-east-1"]`')
+    subparser.add_argument('--rawr_store_name', required=False,
+                           help='optional string of rawr tile store '
+                                'names e.g. `"my-rawr-tiles-us-east-1"`')
     subparser.add_argument('--store_date_prefix', required=False,
                            help='optional string of store bucket date prefix '
+                                'which will override the prefix config'
+                                ' for meta tile and rawr tile s3 output'
                                 'e.g. `20210426`')
     subparser.add_argument('--batch_check_metafile_exists', required=False,
                            help='optional string of a boolean indicating '
@@ -2648,6 +2653,7 @@ def tilequeue_main(argv_args=None):
                                         postgresql_dbnames=args.postgresql_dbnames,  # noqa
                                         postgresql_user=args.postgresql_user,
                                         postgresql_password=args.postgresql_password,  # noqa
+                                        rawr_store_name=args.rawr_store_name,
                                         store_name=args.store_name,
                                         store_date_prefix=args.store_date_prefix,  # noqa
                                         batch_check_metafile_exists=args.batch_check_metafile_exists)  # noqa

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -2529,6 +2529,9 @@ def tilequeue_main(argv_args=None):
     subparser.add_argument('--store_name', required=False,
                            help='optional string of a list of tile store '
                                 'names e.g. `["my-meta-tiles-us-east-1"]`')
+    subparser.add_argument('--rawr_store_name', required=False,
+                           help='optional string of rawr tile store '
+                                'names e.g. `"my-rawr-tiles-us-east-1"`')
     subparser.add_argument('--store_date_prefix', required=False,
                            help='optional string of store bucket date prefix '
                                 'e.g. `20210426`')
@@ -2598,9 +2601,6 @@ def tilequeue_main(argv_args=None):
     subparser.add_argument('--postgresql_password', required=False,
                            help='optional string of db password e.g. '
                                 '`VHcDuAS0SYx2tlgTvtbuCXwlvO4pAtiGCuScJFjq7wersdfqwer`')  # noqa
-    subparser.add_argument('--store_name', required=False,
-                           help='optional string of a list of tile store '
-                                'names e.g. `["my-meta-tiles-us-east-1"]`')
     subparser.add_argument('--rawr_store_name', required=False,
                            help='optional string of rawr tile store '
                                 'names e.g. `"my-rawr-tiles-us-east-1"`')

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -2604,6 +2604,9 @@ def tilequeue_main(argv_args=None):
     subparser.add_argument('--postgresql_password', required=False,
                            help='optional string of db password e.g. '
                                 '`VHcDuAS0SYx2tlgTvtbuCXwlvO4pAtiGCuScJFjq7wersdfqwer`')  # noqa
+    subparser.add_argument('--store_name', required=False,
+                           help='optional string of a list of tile store '
+                                'names e.g. `["my-meta-tiles-us-east-1"]`')
     subparser.add_argument('--rawr_store_name', required=False,
                            help='optional string of rawr tile store '
                                 'names e.g. `"my-rawr-tiles-us-east-1"`')

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -2567,6 +2567,9 @@ def tilequeue_main(argv_args=None):
                            help='optional string of db password e.g. `VHcDuAS0SYx2tlgTvtbuCXwlvO4pAtiGCuScJFjq7wersdfqwer`')  # noqa
     subparser.add_argument('--store_name', required=False,
                            help='optional string of a list of tile store names e.g. `["my-meta-tiles-us-east-1"]`')  # noqa
+    subparser.add_argument('--rawr_store_name', required=False,
+                           help='optional string of rawr tile store '
+                                'names e.g. `"my-rawr-tiles-us-east-1"`')
     subparser.add_argument('--store_date_prefix', required=False,
                            help='optional string of store bucket date prefix e.g. `20210426`')  # noqa
     subparser.add_argument('--batch_check_metafile_exists', required=False,

--- a/tilequeue/config.py
+++ b/tilequeue/config.py
@@ -446,6 +446,7 @@ def make_config_from_argparse(config_file_handle, default_yml=None,
                               postgresql_dbnames=None,
                               postgresql_user=None,
                               postgresql_password=None,
+                              rawr_store_name=None,
                               store_name=None,
                               store_date_prefix=None,
                               batch_check_metafile_exists=None,
@@ -481,62 +482,65 @@ def make_config_from_argparse(config_file_handle, default_yml=None,
 
     # override config values with explicit arguments if set
     if postgresql_hosts is not None:
-        # for high/low zoom metatile
+        # overrides for tilequeue commands: meta-tile-low-zoom and meta-tile
         keys = ['postgresql', 'host']  # attention non-plural form `host`
         value = load(postgresql_hosts)
         _override_cfg(cfg, keys, value)
-        # for RAWR tile
+        # overrides for tilequeue command: rawr-tile
         keys = ['rawr', 'postgresql', 'host']
         _override_cfg(cfg, keys, value)
 
     if postgresql_dbnames is not None:
-        # for high/low zoom metatile
+        # overrides for tilequeue commands: meta-tile-low-zoom and meta-tile
         keys = ['postgresql', 'dbnames']
         value = load(postgresql_dbnames)
         _override_cfg(cfg, keys, value)
-        # for RAWR
+        # overrides for tilequeue command: rawr-tile
         keys = ['rawr', 'postgresql', 'dbname']
         _override_cfg(cfg, keys, value[0])
 
     if postgresql_user is not None:
-        # for high/low zoom metatile
+        # overrides for tilequeue commands: meta-tile-low-zoom and meta-tile
         keys = ['postgresql', 'user']
         value = load(postgresql_user)
         _override_cfg(cfg, keys, value)
-        # for RAWR
+        # overrides for tilequeue command: rawr-tile
         keys = ['rawr', 'postgresql', 'user']
         _override_cfg(cfg, keys, value)
 
     if postgresql_password is not None:
-        # for high/low zoom metatile
+        # overrides for tilequeue commands: meta-tile-low-zoom and meta-tile
         keys = ['postgresql', 'password']
         value = load(postgresql_password)
         _override_cfg(cfg, keys, value)
-        # for RAWR
+        # overrides for tilequeue command: rawr-tile
         keys = ['rawr', 'postgresql', 'password']
         _override_cfg(cfg, keys, value)
 
     if store_name is not None:
-        # for low zoom metatile
+        # overrides for tilequeue commands: meta-tile-low-zoom and meta-tile
         keys = ['store', 'name']
         value = load(store_name)
         _override_cfg(cfg, keys, value)
-        # for RAWR
+
+    if rawr_store_name is not None:
+        value = load(rawr_store_name)
+        # overrides for tilequeue command: rawr-tile
         keys = ['rawr', 'sink', 's3', 'bucket']
-        _override_cfg(cfg, keys, value[0])
-        # for high zoom metatile
+        _override_cfg(cfg, keys, value)
+        # overrides for tilequeue command: meta-tile
         keys = ['rawr', 'source', 's3', 'bucket']
-        _override_cfg(cfg, keys, value[0])
+        _override_cfg(cfg, keys, value)
 
     if store_date_prefix is not None:
-        # for low zoom metatile
+        # overrides for tilequeue command: meta-tile-low-zoom
         keys = ['store', 'date-prefix']
         value = load(store_date_prefix)
         _override_cfg(cfg, keys, value)
-        # for RAWR
+        # overrides for tilequeue command: rawr-tile
         keys = ['rawr', 'sink', 's3', 'prefix']
         _override_cfg(cfg, keys, value)
-        # for high zoom metatile
+        # overrides for tilequeue command: meta-tile
         keys = ['rawr', 'source', 's3', 'prefix']
         _override_cfg(cfg, keys, value)
 


### PR DESCRIPTION
meta-tile command (highzoom) expects to have two configurations for the s3 buckets, one for its output and one that it depends on: the rawr tile bucket. 

We need to provide separate overrides for these two buckets.