### PR TITLE
make every zoom's tile use 4096 as extent

### DIFF
--- a/tests/test_mvt.py
+++ b/tests/test_mvt.py
@@ -81,9 +81,10 @@ class MapboxVectorTileTest(unittest.TestCase):
             for (posargs, kwargs), coord in zip(encode.call_args_list,
                                                 tile_coords):
                 self.assertIn('quantize_bounds', kwargs)
-                quantize_bounds = kwargs['quantize_bounds']
-                extent = int(round((quantize_bounds[2] - quantize_bounds[0]) /
-                                   resolution))
+                # quantize_bounds = kwargs['quantize_bounds']
+                # extent = int(round((quantize_bounds[2] - quantize_bounds[0]) /
+                #                    resolution))
+                extent = 4096
                 self.assertIn('extents', kwargs)
                 actual_extent = kwargs['extents']
                 self.assertEquals(extent, actual_extent,

--- a/tests/test_mvt.py
+++ b/tests/test_mvt.py
@@ -81,6 +81,9 @@ class MapboxVectorTileTest(unittest.TestCase):
             for (posargs, kwargs), coord in zip(encode.call_args_list,
                                                 tile_coords):
                 self.assertIn('quantize_bounds', kwargs)
+                # We hardcoded the extent to be 4096 in
+                # https://github.com/tilezen/tilequeue/pull/404
+                # thus the extent calculation is thus commented out
                 # quantize_bounds = kwargs['quantize_bounds']
                 # extent = int(round((quantize_bounds[2] - quantize_bounds[0]) /
                 #                    resolution))

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -523,10 +523,6 @@ def format_coord(
         # before, the scale is calculated by
         # _calculate_scale(scale, coord, nominal_zoom)
         if cut_coord == coord:
-            # we hardcoded the extent to be 4096 in
-            # https://github.com/tilezen/tilequeue/pull/404
-            # before, the scale is calculated by
-            # _calculate_scale(scale, coord, nominal_zoom)
             tiles = _format_feature_layers(
                 processed_feature_layers, coord, nominal_zoom,
                 max_zoom_with_changes, formats, unpadded_bounds, scale,

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -518,6 +518,10 @@ def format_coord(
 
     formatted_tiles = []
     for cut_coord in cut_coords:
+        # we hardcoded the extent to be 4096 in
+        # https://github.com/tilezen/tilequeue/pull/404
+        # before, the scale is calculated by
+        # _calculate_scale(scale, coord, nominal_zoom)
         if cut_coord == coord:
             # we hardcoded the extent to be 4096 in
             # https://github.com/tilezen/tilequeue/pull/404

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -524,12 +524,12 @@ def format_coord(
         # _calculate_scale(scale, coord, nominal_zoom)
         if cut_coord == coord:
             tiles = _format_feature_layers(
-                processed_feature_layers, coord, nominal_zoom,
+                processed_feature_layers, cut_coord, nominal_zoom,
                 max_zoom_with_changes, formats, unpadded_bounds, scale,
                 buffer_cfg)
         else:
             tiles = _cut_child_tiles(
-                processed_feature_layers, coord, nominal_zoom, formats,
+                processed_feature_layers, cut_coord, nominal_zoom, formats,
                 unpadded_bounds, scale, buffer_cfg)
 
         formatted_tiles.extend(tiles)

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -518,18 +518,19 @@ def format_coord(
 
     formatted_tiles = []
     for cut_coord in cut_coords:
-        cut_scale = _calculate_scale(scale, coord, nominal_zoom)
-
         if cut_coord == coord:
-            # no need for cutting if this is the original tile.
+            # we hardcoded the extent to be 4096 in
+            # https://github.com/tilezen/tilequeue/pull/404
+            # before, the scale is calculated by
+            # _calculate_scale(scale, coord, nominal_zoom)
             tiles = _format_feature_layers(
-                processed_feature_layers, coord, nominal_zoom, max_zoom_with_changes, formats,
-                unpadded_bounds, cut_scale, buffer_cfg)
-
+                processed_feature_layers, coord, nominal_zoom,
+                max_zoom_with_changes, formats, unpadded_bounds, scale,
+                buffer_cfg)
         else:
             tiles = _cut_child_tiles(
-                processed_feature_layers, cut_coord, nominal_zoom, max_zoom_with_changes, formats,
-                _calculate_scale(scale, cut_coord, nominal_zoom), buffer_cfg)
+                processed_feature_layers, coord, nominal_zoom, formats,
+                unpadded_bounds, scale, buffer_cfg)
 
         formatted_tiles.extend(tiles)
 

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -529,8 +529,8 @@ def format_coord(
                 buffer_cfg)
         else:
             tiles = _cut_child_tiles(
-                processed_feature_layers, cut_coord, nominal_zoom, formats,
-                unpadded_bounds, scale, buffer_cfg)
+                processed_feature_layers, cut_coord, nominal_zoom,
+                max_zoom_with_changes, formats, scale, buffer_cfg)
 
         formatted_tiles.extend(tiles)
 


### PR DESCRIPTION
The scale used to be 8192 in some circumstances, but we think that's not necessary so we reduce it to 4096 for all zooms.

### Test
Rebuilt England area using with the change and found all zooms extent are 4096 now.