### PR TITLE
adding a keyFormatType without a hash

### DIFF
--- a/tilequeue/store.py
+++ b/tilequeue/store.py
@@ -36,6 +36,9 @@ class KeyFormatType(Enum):
     # prefix comes before hash
     prefix_hash = 2
 
+    # hash omitted
+    simple = 3
+
 
 def int_if_exact(x):
     try:
@@ -71,6 +74,8 @@ class S3TileKeyGenerator(object):
                 key_format = '%(hash)s/%(prefix)s/%(path)s'
             elif key_format_type == KeyFormatType.prefix_hash:
                 key_format = '%(prefix)s/%(hash)s/%(path)s'
+            elif key_format_type == KeyFormatType.simple:
+                key_format = '%(prefix)s/%(path)s'
             else:
                 raise ValueError('unknown key_format_type: %r' %
                                  key_format_type)
@@ -585,6 +590,8 @@ def make_s3_tile_key_generator(yml_cfg):
         key_format_type = KeyFormatType.hash_prefix
     elif key_format_type_str == 'prefix-hash':
         key_format_type = KeyFormatType.prefix_hash
+    elif key_format_type_str == 'no-hash':
+        key_format_type = KeyFormatType.simple
     else:
         raise ValueError('unknown s3 key-format: %r' % key_format_type_str)
     return S3TileKeyGenerator(key_format_type=key_format_type)

--- a/tilequeue/store.py
+++ b/tilequeue/store.py
@@ -80,7 +80,7 @@ class S3TileKeyGenerator(object):
                 raise ValueError('unknown key_format_type: %r' %
                                  key_format_type)
 
-        self.key_format = '%(prefix)s/%(path)s'
+        self.key_format = key_format
 
     def __call__(self, prefix, coord, extension):
         path_to_hash = '%d/%d/%d.%s' % (

--- a/tilequeue/store.py
+++ b/tilequeue/store.py
@@ -69,17 +69,18 @@ class S3TileKeyGenerator(object):
     def __init__(self, key_format_type=None, key_format=None):
         if key_format is not None and key_format_type is not None:
             raise ValueError('key_format and key_format_type both set')
-        if key_format_type is not None:
-            if key_format_type == KeyFormatType.hash_prefix:
-                key_format = '%(hash)s/%(prefix)s/%(path)s'
-            elif key_format_type == KeyFormatType.prefix_hash:
-                key_format = '%(prefix)s/%(hash)s/%(path)s'
-            elif key_format_type == KeyFormatType.simple:
-                key_format = '%(prefix)s/%(path)s'
-            else:
-                raise ValueError('unknown key_format_type: %r' %
-                                 key_format_type)
-        self.key_format = key_format
+        # if key_format_type is not None:
+        #     if key_format_type == KeyFormatType.hash_prefix:
+        #         key_format = '%(hash)s/%(prefix)s/%(path)s'
+        #     elif key_format_type == KeyFormatType.prefix_hash:
+        #         key_format = '%(prefix)s/%(hash)s/%(path)s'
+        #     elif key_format_type == KeyFormatType.simple:
+        #         key_format = '%(prefix)s/%(path)s'
+        #     else:
+        #         raise ValueError('unknown key_format_type: %r' %
+        #                          key_format_type)
+
+        self.key_format = '%(prefix)s/%(path)s'
 
     def __call__(self, prefix, coord, extension):
         path_to_hash = '%d/%d/%d.%s' % (

--- a/tilequeue/store.py
+++ b/tilequeue/store.py
@@ -69,16 +69,16 @@ class S3TileKeyGenerator(object):
     def __init__(self, key_format_type=None, key_format=None):
         if key_format is not None and key_format_type is not None:
             raise ValueError('key_format and key_format_type both set')
-        # if key_format_type is not None:
-        #     if key_format_type == KeyFormatType.hash_prefix:
-        #         key_format = '%(hash)s/%(prefix)s/%(path)s'
-        #     elif key_format_type == KeyFormatType.prefix_hash:
-        #         key_format = '%(prefix)s/%(hash)s/%(path)s'
-        #     elif key_format_type == KeyFormatType.simple:
-        #         key_format = '%(prefix)s/%(path)s'
-        #     else:
-        #         raise ValueError('unknown key_format_type: %r' %
-        #                          key_format_type)
+        if key_format_type is not None:
+            if key_format_type == KeyFormatType.hash_prefix:
+                key_format = '%(hash)s/%(prefix)s/%(path)s'
+            elif key_format_type == KeyFormatType.prefix_hash:
+                key_format = '%(prefix)s/%(hash)s/%(path)s'
+            elif key_format_type == KeyFormatType.simple:
+                key_format = '%(prefix)s/%(path)s'
+            else:
+                raise ValueError('unknown key_format_type: %r' %
+                                 key_format_type)
 
         self.key_format = '%(prefix)s/%(path)s'
 
@@ -591,7 +591,7 @@ def make_s3_tile_key_generator(yml_cfg):
         key_format_type = KeyFormatType.hash_prefix
     elif key_format_type_str == 'prefix-hash':
         key_format_type = KeyFormatType.prefix_hash
-    elif key_format_type_str == 'no-hash':
+    elif key_format_type_str == 'simple':
         key_format_type = KeyFormatType.simple
     else:
         raise ValueError('unknown s3 key-format: %r' % key_format_type_str)

--- a/tilequeue/store.py
+++ b/tilequeue/store.py
@@ -36,8 +36,8 @@ class KeyFormatType(Enum):
     # prefix comes before hash
     prefix_hash = 2
 
-    # hash omitted
-    simple = 3
+    # just prefix, no hash
+    prefix = 3
 
 
 def int_if_exact(x):
@@ -74,7 +74,7 @@ class S3TileKeyGenerator(object):
                 key_format = '%(hash)s/%(prefix)s/%(path)s'
             elif key_format_type == KeyFormatType.prefix_hash:
                 key_format = '%(prefix)s/%(hash)s/%(path)s'
-            elif key_format_type == KeyFormatType.simple:
+            elif key_format_type == KeyFormatType.prefix:
                 key_format = '%(prefix)s/%(path)s'
             else:
                 raise ValueError('unknown key_format_type: %r' %
@@ -591,8 +591,8 @@ def make_s3_tile_key_generator(yml_cfg):
         key_format_type = KeyFormatType.hash_prefix
     elif key_format_type_str == 'prefix-hash':
         key_format_type = KeyFormatType.prefix_hash
-    elif key_format_type_str == 'simple':
-        key_format_type = KeyFormatType.simple
+    elif key_format_type_str == 'prefix':
+        key_format_type = KeyFormatType.prefix
     else:
         raise ValueError('unknown s3 key-format: %r' % key_format_type_str)
     return S3TileKeyGenerator(key_format_type=key_format_type)


### PR DESCRIPTION
Adding a new keyFormat type `simple` that doesn't include the hash.