### PR TITLE
add support for preprocessed inline geojson layers

### DIFF
--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -544,6 +544,7 @@ def parse_layer_data(query_cfg, buffer_cfg, cfg_path):
             query_bounds_pad_fn=create_query_bounds_pad_fn(
                 buffer_cfg, layer_name),
             tolerance=float(layer_config.get('tolerance', 1.0)),
+            layer_path=layer_config.get('layer_path'),
         )
         layer_data.append(layer_datum)
         if layer_name in all_layer_names:

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -2177,8 +2177,9 @@ def tilequeue_meta_tile(cfg, args):
         # each coord here is the unit of work now
         pyramid_coords = [job_coord]
         pyramid_coords.extend(coord_children_range(job_coord, zoom_stop))
-        # for brevity of testing it is sometimes convenient to reduce to a single child coord
-        # pyramid_coords = [Coordinate(zoom=13, column=2411, row=3080)]
+        # for brevity of testing it is sometimes convenient to reduce to a single child coord that covers your test area
+        # this makes it so that only that metatile is built rather than the whole tile pyramid which can save 20-50min
+        # pyramid_coords = [Coordinate(zoom=13, column=2411, row=3080)] # this example covers liberty island at max zoom
         coord_data = [dict(coord=x) for x in pyramid_coords]
 
         try:

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -2177,6 +2177,8 @@ def tilequeue_meta_tile(cfg, args):
         # each coord here is the unit of work now
         pyramid_coords = [job_coord]
         pyramid_coords.extend(coord_children_range(job_coord, zoom_stop))
+        # for brevity of testing it is sometimes convenient to reduce to a single child coord
+        #pyramid_coords = [Coordinate(zoom=13, column=2411, row=3080)]
         coord_data = [dict(coord=x) for x in pyramid_coords]
 
         try:

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -544,7 +544,7 @@ def parse_layer_data(query_cfg, buffer_cfg, cfg_path):
             query_bounds_pad_fn=create_query_bounds_pad_fn(
                 buffer_cfg, layer_name),
             tolerance=float(layer_config.get('tolerance', 1.0)),
-            layer_path=layer_config.get('layer_path'),
+            pre_processed_layer_path=layer_config.get('pre_processed_layer_path'),
         )
         layer_data.append(layer_datum)
         if layer_name in all_layer_names:
@@ -2177,7 +2177,6 @@ def tilequeue_meta_tile(cfg, args):
         # each coord here is the unit of work now
         pyramid_coords = [job_coord]
         pyramid_coords.extend(coord_children_range(job_coord, zoom_stop))
-        pyramid_coords = [Coordinate(zoom=13, column=2411, row=3080)] # TODO: testing hack remove
         coord_data = [dict(coord=x) for x in pyramid_coords]
 
         try:

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -2177,6 +2177,7 @@ def tilequeue_meta_tile(cfg, args):
         # each coord here is the unit of work now
         pyramid_coords = [job_coord]
         pyramid_coords.extend(coord_children_range(job_coord, zoom_stop))
+        pyramid_coords = [Coordinate(zoom=13, column=2411, row=3080)] # TODO: testing hack remove
         coord_data = [dict(coord=x) for x in pyramid_coords]
 
         try:

--- a/tilequeue/command.py
+++ b/tilequeue/command.py
@@ -2178,7 +2178,7 @@ def tilequeue_meta_tile(cfg, args):
         pyramid_coords = [job_coord]
         pyramid_coords.extend(coord_children_range(job_coord, zoom_stop))
         # for brevity of testing it is sometimes convenient to reduce to a single child coord
-        #pyramid_coords = [Coordinate(zoom=13, column=2411, row=3080)]
+        # pyramid_coords = [Coordinate(zoom=13, column=2411, row=3080)]
         coord_data = [dict(coord=x) for x in pyramid_coords]
 
         try:

--- a/tilequeue/process.py
+++ b/tilequeue/process.py
@@ -522,10 +522,10 @@ def _calculate_scale(scale, coord, nominal_zoom):
 
 
 def _load_inline_layer(layer_path):
-    # we can optionally load geojson layers from file all we need is a file path per layer name. we expect the coords to
-    # already be in mercator projection and we only fill out the minimal structure of the feature tuple, ie there's no ID,
-    # most of the datum stuff is missing. we are mostly worried about the shape and properties and we skip any layers
-    # that are configured but cannot be loaded for whatever reason
+    # we can optionally load geojson layers from file all we need is a file path. we expect the coordinates to already
+    # be in mercator projection and we only fill out the minimal structure of the feature tuple, ie there's no ID. if
+    # the path is given and the file exists, we expect to be able to load the layer's features. so if the json is
+    # malformed or shapely can't make sense of the geom then we'll raise
     features = []
 
     # has to exist and has to be geojson for now
@@ -534,14 +534,12 @@ def _load_inline_layer(layer_path):
 
     # load the geojson into a shapely geometry collection
     with open(layer_path) as fh:
-        try:
-            fc = json.load(fh)
-            # skip if this isnt pseudo mercator
-            if fc['crs']['properties']['name'] != 'urn:ogc:def:crs:EPSG::3857':
-                return features
-            gc = GeometryCollection([shape(feature['geometry']) for feature in fc['features']])
-        except:
+        fc = json.load(fh)
+        # skip if this isnt pseudo mercator
+        if fc['crs']['properties']['name'] != 'urn:ogc:def:crs:EPSG::3857':
             return features
+        gc = GeometryCollection([shape(feature['geometry']) for feature in fc['features']])
+
 
     # add the features geometries with their properties (values must be strings) in tuples
     for geom, feat in itertools.izip(gc.geoms, fc['features']):

--- a/tilequeue/query/__init__.py
+++ b/tilequeue/query/__init__.py
@@ -179,6 +179,9 @@ def _make_layer_info(layer_data, process_yaml_cfg):
     functions = _parse_yaml_functions(process_yaml_cfg)
 
     for layer_datum in layer_data:
+        # preprocessed layers are not from the database and not found in the rawr tile
+        if layer_datum.get('pre_processed_layer_path') is not None:
+            continue
         name = layer_datum['name']
         min_zoom_fn, props_fn = functions[name]
         shape_types = ShapeType.parse_set(layer_datum['geometry_types'])


### PR DESCRIPTION
just what the title says. you can now modify queries.yaml to reference layers from mercator projected geojson files. the way in which ive implemented this is fairly lightweight in that we dont support transforms or filters on the initial data (ie we dont load any yaml files like water.yaml buildings.yaml etc) because we expect the layer to be pretty much already in its final format. this does mean however that postprocessing transforms are allowed since they dont have any filtering or column juggling.

this pr is a corollary to the one over here: https://github.com/tilezen/vector-datasource/pull/2095