### PR TITLE
Update requirements.txt to pin boto3 and botocore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 appdirs==1.4.3
 argparse==1.4.0
 boto==2.48.0
+boto3==1.15.18
+botocore==1.18.18
 edtf==2.6.0
 enum34==1.1.6
 future==0.16.0


### PR DESCRIPTION
```
boto3==1.15.18
botocore==1.18.18
```
is necessary for the s3 role assume to work.


### Test

Manually tested on tile build machine for these versions